### PR TITLE
Clear errno before call to strtol(3).

### DIFF
--- a/checkpolicy/checkpolicy.c
+++ b/checkpolicy/checkpolicy.c
@@ -456,7 +456,9 @@ int main(int argc, char **argv)
 			mlspol = 1;
 			break;
 		case 'c':{
-				long int n = strtol(optarg, NULL, 10);
+				long int n;
+				errno = 0;
+				n = strtol(optarg, NULL, 10);
 				if (errno) {
 					fprintf(stderr,
 						"Invalid policyvers specified: %s\n",


### PR DESCRIPTION
Since strtol(3) doesn't clear errno on success, anything that sets
errno prior to this call will make it look like the call failed. This
happens when built with ASAN.

Signed-off-by: Dan Albert danalbert@google.com
