### PR TITLE
sepolicy: use ugettext() and unicode() for localized strings

### DIFF
--- a/policycoreutils/sepolicy/sepolicy.py
+++ b/policycoreutils/sepolicy/sepolicy.py
@@ -26,15 +26,16 @@ import selinux
 import sepolicy
 from sepolicy import get_os_version, get_conditionals, get_conditionals_format_text
 import argparse
+
 import gettext
 PROGNAME="policycoreutils"
 gettext.bindtextdomain(PROGNAME, "/usr/share/locale")
 gettext.textdomain(PROGNAME)
 try:
     gettext.install(PROGNAME,
-                    localedir="/usr/share/locale",
-                    unicode=False,
-                    codeset = 'utf-8')
+                    localedir = "/usr/share/locale",
+                    unicode   = True,
+                    codeset   = 'utf-8')
 except IOError:
     import __builtin__
     __builtin__.__dict__['_'] = unicode
@@ -643,10 +644,10 @@ if __name__ == '__main__':
         args.func(args)
         sys.exit(0)
     except ValueError,e:
-        sys.stderr.write("%s: %s\n" % (e.__class__.__name__, str(e)))
+        sys.stderr.write("%s: %s\n" % (e.__class__.__name__, unicode(e)))
         sys.exit(1)
     except IOError,e:
-        sys.stderr.write("%s: %s\n" % (e.__class__.__name__, str(e)))
+        sys.stderr.write("%s: %s\n" % (e.__class__.__name__, unicode(e)))
         sys.exit(1)
     except KeyboardInterrupt:
         print "Out"


### PR DESCRIPTION
When an user uses non-standard localization with utf-8 string, he can get traceback message due use of  8-bit strings instead of unicode strings:

  File "/bin/sepolicy", line 647, in <module>
    sys.stderr.write("%s: %s\n" % (e.__class__.__name__, str(e)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 48: ordinal not in range(128)

This patch fixes this for sepolicy tool.


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1177380

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>