### PR TITLE
sepolicy-generate: Handle more reserved port types

### DIFF
--- a/policycoreutils/sepolicy/sepolicy/generate.py
+++ b/policycoreutils/sepolicy/sepolicy/generate.py
@@ -90,7 +90,9 @@ def get_rpm_nvr_list(package):
 def get_all_ports():
     dict = {}
     for p in sepolicy.info(sepolicy.PORT):
-        if p['type'] == "reserved_port_t" or \
+        if p['type'] == "ephemeral_port_t" or \
+                p['type'] == "unreserved_port_t" or \
+                p['type'] == "reserved_port_t" or \
                 p['type'] == "port_t" or \
                 p['type'] == "hi_reserved_port_t":
             continue


### PR DESCRIPTION
Currently only reserved_port_t, port_t and hi_reserved_port_t
are handled as special when making a ports-dictionary.
However, as fas as corenetwork.te.in of serefpolicy,
both unreserved_port_t and ephemeral_port_t also handled
in the same way.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>