### PR TITLE
Fix -Wreturn-type issues.

### DIFF
--- a/checkpolicy/module_compiler.c
+++ b/checkpolicy/module_compiler.c
@@ -300,7 +300,7 @@ role_datum_t *declare_role(unsigned char isattr)
 			return dest_role;	/* role already declared for this block */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -363,7 +363,7 @@ type_datum_t *declare_type(unsigned char primary, unsigned char isattr)
 			return typdatum;
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -499,7 +499,7 @@ user_datum_t *declare_user(void)
 			return dest_user;	/* user already declared for this block */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -804,7 +804,7 @@ int require_class(int pass)
 			break;
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 
@@ -917,7 +917,7 @@ static int require_role_or_attribute(int pass, unsigned char isattr)
 			return 0;	/* role already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -980,7 +980,7 @@ static int require_type_or_attribute(int pass, unsigned char isattr)
 			return 0;	/* type already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -1041,7 +1041,7 @@ int require_user(int pass)
 			return 0;	/* user already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -1092,7 +1092,7 @@ static int require_bool_tunable(int pass, int is_tunable)
 			return 0;	/* boolean already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -1165,7 +1165,7 @@ int require_sens(int pass)
 			return 0;	/* sensitivity already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }
@@ -1218,7 +1218,7 @@ int require_cat(int pass)
 			return 0;	/* category already required */
 		}
 	default:{
-			assert(0);	/* should never get here */
+			abort();	/* should never get here */
 		}
 	}
 }


### PR DESCRIPTION
`assert()` only prevents `-Wreturn-type` from firing if asserts are
enabled. Add `__builtin_unreachable()` to make it work with `-UNDEBUG`.