### PR TITLE
Load libsepol.so.1 instead of libsepol.so

### DIFF
--- a/libsemanage/utils/semanage_migrate_store
+++ b/libsemanage/utils/semanage_migrate_store
@@ -10,7 +10,7 @@ from optparse import OptionParser
 
 import ctypes
 
-sepol = ctypes.cdll.LoadLibrary('libsepol.so')
+sepol = ctypes.cdll.LoadLibrary('libsepol.so.1')
 
 try:
 	import selinux


### PR DESCRIPTION
libsepol.so symlink is usually part of the development package, try to load the library directly instead