### PR TITLE
[sandbox] init script of sandbox returns an improper return code in s…

### DIFF
--- a/policycoreutils/sandbox/sandbox.init
+++ b/policycoreutils/sandbox/sandbox.init
@@ -42,12 +42,15 @@ stop() {
 }
 
 status() {
+        EXIT_CODE=0
 	if [ -f "$LOCKFILE" ]; then 
 	    echo "$base is running"
+	    EXIT_CODE=0
 	else
 	    echo "$base is stopped"
+	    EXIT_CODE=3
 	fi
-	exit 0
+	exit $EXIT_CODE
 }
 
 case "$1" in


### PR DESCRIPTION
…tatus function

Previous sandbox's init script returns 0 only in status function.
This return code causes wrong service status report in system-config-services.

This fix will change the return code to return a proper code for system-config-services.

Signed-off-by: Keigo Noha <knoha@redhat.com>