### PR TITLE
read_spec_entry: fail on non-ascii

### DIFF
--- a/libselinux/src/label_internal.h
+++ b/libselinux/src/label_internal.h
@@ -140,6 +140,6 @@ compat_validate(struct selabel_handle *rec,
  * The read_spec_entries function may be used to
  * replace sscanf to read entries from spec files.
  */
-extern int read_spec_entries(char *line_buf, int num_args, ...);
+extern int read_spec_entries(char *line_buf, const char **errbuf, int num_args, ...);
 
 #endif				/* _SELABEL_INTERNAL_H_ */

--- a/libselinux/src/label_support.c
+++ b/libselinux/src/label_support.c
@@ -10,17 +10,24 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <errno.h>
 #include "label_internal.h"
 
 /*
- * The read_spec_entries and read_spec_entry functions may be used to
- * replace sscanf to read entries from spec files. The file and
- * property services now use these.
+ * Read an entry from a spec file (e.g. file_contexts)
+ * entry - Buffer to allocate for the entry.
+ * ptr - current location of the line to be processed.
+ * returns  - 0 on success and *entry is set to be a null
+ *            terminated value. On Error it returns -1 and
+ *            errno will be set.
+ *
  */
-static inline int read_spec_entry(char **entry, char **ptr, int *len)
+static inline int read_spec_entry(char **entry, char **ptr, int *len, const char **errbuf)
 {
 	*entry = NULL;
 	char *tmp_buf = NULL;
+
+	*errbuf = NULL;
 
 	while (isspace(**ptr) && **ptr != '\0')
 		(*ptr)++;
@@ -29,6 +36,11 @@ static inline int read_spec_entry(char **entry, char **ptr, int *len)
 	*len = 0;
 
 	while (!isspace(**ptr) && **ptr != '\0') {
+		if (!isascii(**ptr)) {
+			errno = EINVAL;
+			*errbuf = "Non-ASCII characters found";
+			return -1;
+		}
 		(*ptr)++;
 		(*len)++;
 	}
@@ -44,13 +56,16 @@ static inline int read_spec_entry(char **entry, char **ptr, int *len)
 
 /*
  * line_buf - Buffer containing the spec entries .
+ * errbuf   - Double pointer used for passing back specific error messages.
  * num_args - The number of spec parameter entries to process.
  * ...      - A 'char **spec_entry' for each parameter.
- * returns  - The number of items processed.
+ * returns  - The number of items processed. On error, it returns -1 with errno
+ *            set and may set errbuf to a specific error message.
  *
  * This function calls read_spec_entry() to do the actual string processing.
+ * As such, can return anything from that function as well.
  */
-int hidden read_spec_entries(char *line_buf, int num_args, ...)
+int hidden read_spec_entries(char *line_buf, const char **errbuf, int num_args, ...)
 {
 	char **spec_entry, *buf_p;
 	int len, rc, items, entry_len = 0;
@@ -85,7 +100,7 @@ int hidden read_spec_entries(char *line_buf, int num_args, ...)
 			return items;
 		}
 
-		rc = read_spec_entry(spec_entry, &buf_p, &entry_len);
+		rc = read_spec_entry(spec_entry, &buf_p, &entry_len, errbuf);
 		if (rc < 0) {
 			va_end(ap);
 			return rc;


### PR DESCRIPTION
Inserting non-ascii characters into a file_contexts file can cause a
failure on labeling but still result in a successful build.

Hard error on non-ascii characters.

Signed-off-by: William Roberts <william.c.roberts@intel.com>