### PR TITLE
seobject: Handle python error returns correctly

### DIFF
--- a/python/semanage/seobject.py
+++ b/python/semanage/seobject.py
@@ -1953,10 +1953,12 @@ class fcontextRecords(semanageRecords):
             if not exists:
                 raise ValueError(_("File context for %s is not defined") % target)
 
-        (rc, fcontext) = semanage_fcontext_query_local(self.sh, k)
-        if rc < 0:
-            (rc, fcontext) = semanage_fcontext_query(self.sh, k)
-            if rc < 0:
+        try:
+            (rc, fcontext) = semanage_fcontext_query_local(self.sh, k)
+        except OSError:
+            try:
+                (rc, fcontext) = semanage_fcontext_query(self.sh, k)
+            except OSError:
                 raise ValueError(_("Could not query file context for %s") % target)
 
         if setype != "<<none>>":


### PR DESCRIPTION
Following commit 9792099f (Properly build the swig exception file even if the headers are missing),
the underlying semanage_fcontext_query_local and semanage_fcontext_query calls result in an OSError
return. This results in the following error when attempting to modify a fcontext defined in the
systems base policy.

    libsemanage.dbase_llist_query: could not query record value (No such file or directory).
    OSError: No such file or directory

To resolve the error, handle the OSError exception, but retain the previous query operation.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1398427

Signed-off-by: Kyle Walker <kwalker@redhat.com>