### PR TITLE
Portability patches

### DIFF
--- a/libselinux/src/Makefile
+++ b/libselinux/src/Makefile
@@ -59,7 +59,8 @@ ifeq ($(COMPILER), gcc)
 EXTRA_CFLAGS = -fipa-pure-const -Wlogical-op -Wpacked-bitfield-compat -Wsync-nand \
 	-Wcoverage-mismatch -Wcpp -Wformat-contains-nul -Wnormalized=nfc -Wsuggest-attribute=const \
 	-Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wtrampolines -Wjump-misses-init \
-	-Wno-suggest-attribute=pure -Wno-suggest-attribute=const -Wp,-D_FORTIFY_SOURCE=2
+	-Wno-suggest-attribute=pure -Wno-suggest-attribute=const \
+	-Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2
 else
 EXTRA_CFLAGS = -Wunused-command-line-argument
 endif

--- a/libselinux/utils/Makefile
+++ b/libselinux/utils/Makefile
@@ -32,7 +32,8 @@ CFLAGS ?= -O -Wall -W -Wundef -Wformat-y2k -Wformat-security -Winit-self -Wmissi
           -Wformat-extra-args -Wformat-zero-length -Wformat=2 -Wmultichar \
           -Woverflow -Wpointer-to-int-cast -Wpragmas \
           -Wno-missing-field-initializers -Wno-sign-compare \
-          -Wno-format-nonliteral -Wframe-larger-than=$(MAX_STACK_SIZE) -Wp,-D_FORTIFY_SOURCE=2 \
+          -Wno-format-nonliteral -Wframe-larger-than=$(MAX_STACK_SIZE) \
+          -Wp,-U_FORTIFY_SOURCE -Wp,-D_FORTIFY_SOURCE=2 \
           -fstack-protector-all --param=ssp-buffer-size=4 -fexceptions \
           -fasynchronous-unwind-tables -fdiagnostics-show-option -funit-at-a-time \
           -Werror -Wno-aggregate-return -Wno-redundant-decls \

--- a/libsepol/include/sepol/ibendport_record.h
+++ b/libsepol/include/sepol/ibendport_record.h
@@ -4,9 +4,10 @@
 #include <stddef.h>
 #include <sepol/context_record.h>
 #include <sepol/handle.h>
-#include <sys/cdefs.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct sepol_ibendport;
 struct sepol_ibendport_key;
@@ -64,5 +65,8 @@ extern int sepol_ibendport_clone(sepol_handle_t *handle,
 
 extern void sepol_ibendport_free(sepol_ibendport_t *ibendport);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/libsepol/include/sepol/ibendports.h
+++ b/libsepol/include/sepol/ibendports.h
@@ -4,9 +4,10 @@
 #include <sepol/handle.h>
 #include <sepol/policydb.h>
 #include <sepol/ibendport_record.h>
-#include <sys/cdefs.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Return the number of ibendports */
 extern int sepol_ibendport_count(sepol_handle_t *handle,
@@ -41,5 +42,9 @@ extern int sepol_ibendport_iterate(sepol_handle_t *handle,
 				   int (*fn)(const sepol_ibendport_t *ibendport,
 					     void *fn_arg), void *arg);
 
-__END_DECLS
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/libsepol/include/sepol/ibpkey_record.h
+++ b/libsepol/include/sepol/ibpkey_record.h
@@ -5,11 +5,12 @@
 #include <stdint.h>
 #include <sepol/context_record.h>
 #include <sepol/handle.h>
-#include <sys/cdefs.h>
 
 #define INET6_ADDRLEN 16
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct sepol_ibpkey;
 struct sepol_ibpkey_key;
@@ -71,5 +72,9 @@ extern int sepol_ibpkey_clone(sepol_handle_t *handle,
 
 extern void sepol_ibpkey_free(sepol_ibpkey_t *ibpkey);
 
-__END_DECLS
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/libsepol/include/sepol/ibpkeys.h
+++ b/libsepol/include/sepol/ibpkeys.h
@@ -4,9 +4,11 @@
 #include <sepol/handle.h>
 #include <sepol/policydb.h>
 #include <sepol/ibpkey_record.h>
-#include <sys/cdefs.h>
 
-__BEGIN_DECLS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Return the number of ibpkeys */
 extern int sepol_ibpkey_count(sepol_handle_t *handle,
@@ -40,5 +42,9 @@ extern int sepol_ibpkey_iterate(sepol_handle_t *handle,
 				int (*fn)(const sepol_ibpkey_t *ibpkey,
 					  void *fn_arg), void *arg);
 
-__END_DECLS
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
This is a first batch of small portability fixes. It removes a few instances of non-portable functions, problems with hardened toolchains defining FORTIFY_SOURCE and removes usage of __BEGIN_DECLS.

While I guess that the first two commits of removing __BEGIN_DECLS and the patch for FORTIFY_SOURCE are uncontroversial, I can imagine the removal of getpwent_r being a bit more so due to the alternative being non-reentrant. But to the best of my knowledge the code in question is not even called in a threaded context, so I actually doubt it matters much. Anyway, seeing that I'm new to this code base I could very likely be wrong.