### PR TITLE
CleanSpec.mk: remove

### DIFF
--- a/CleanSpec.mk
+++ b/CleanSpec.mk
@@ -1,2 +1,0 @@
-# This empty CleanSpec.mk file will prevent the build system
-# from descending into subdirs.


### PR DESCRIPTION
The Android.mk files were removed but the CleanSpec.mk lingered on,
remove it.

Signed-off-by: William Roberts <william.c.roberts@intel.com>