### PR TITLE
libsepol: free ibendport device names

### DIFF
--- a/libsepol/src/policydb.c
+++ b/libsepol/src/policydb.c
@@ -1420,6 +1420,8 @@ void ocontext_selinux_free(ocontext_t **ocontexts)
 			if (i == OCON_ISID || i == OCON_FS || i == OCON_NETIF
 				|| i == OCON_FSUSE)
 				free(ctmp->u.name);
+			else if (i == OCON_IBENDPORT)
+				free(ctmp->u.ibendport.dev_name);
 			free(ctmp);
 		}
 	}


### PR DESCRIPTION
When reading policy, ibendport device names are allocated in
ocontext_read_selinux() but they are not freed when calling
sepol_policydb_free();

Fix this by freeing them in ocontext_selinux_free().

Signed-off-by: Jan Zarsky <jzarsky@redhat.com>