### PR TITLE
libsemanage: properly check return value of iterate function

### DIFF
--- a/libsemanage/src/database_llist.c
+++ b/libsemanage/src/database_llist.c
@@ -263,7 +263,7 @@ int dbase_llist_iterate(semanage_handle_t * handle,
 		if (rc < 0)
 			goto err;
 
-		else if (rc > 1)
+		else if (rc > 0)
 			break;
 	}
 


### PR DESCRIPTION
Function dbase_llist_iterate iterates over records and checks return
value of iterate function. According to a manpage semanage_iterate(3),
handler can return value 1 for early exit. dbase_llist_iterate
currently checks for return value > 1, which does not include
expected value 1. This affects most of the semanage_*_iterate
and semanage_*_local functions.

Signed-off-by: Jan Zarsky <jzarsky@redhat.com>