### PR TITLE
libsepol: Export sepol_polcap_getnum/name functions

### DIFF
--- a/libsepol/src/libsepol.map.in
+++ b/libsepol/src/libsepol.map.in
@@ -56,4 +56,6 @@ LIBSEPOL_1.1 {
 	sepol_module_policydb_to_cil;
 	sepol_kernel_policydb_to_cil;
 	sepol_kernel_policydb_to_conf;
+	sepol_polcap_getnum;
+	sepol_polcap_getname;
 } LIBSEPOL_1.0;


### PR DESCRIPTION
Export the sepol_polcap_getnum/name() functions to users of
the shared library.  This will enable SETools to stop depending
on the static library.

Note that we may want to move polcaps.h up one level since
the convention is that headers directly under include/sepol are
shared library APIs while headers under include/sepol/policydb
are limited to static users.  However, this will unnecessarily
break the build for existing static users so it is deferred.

Suggested-by: Chris PeBenito <pebenito@ieee.org>
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>