### PR TITLE
python/sepolgen: Try to translate SELinux contexts to raw

### DIFF
--- a/python/sepolgen/src/sepolgen/refpolicy.py
+++ b/python/sepolgen/src/sepolgen/refpolicy.py
@@ -284,6 +284,11 @@ class SecurityContext(Leaf):
 
         Raises ValueError if the string is not parsable as a security context.
         """
+        # try to translate the context string to raw form
+        raw = selinux.selinux_trans_to_raw_context(context)
+        if raw[0] == 0:
+            context = raw[1]
+
         fields = context.split(":")
         if len(fields) < 3:
             raise ValueError("context string [%s] not in a valid format" % context)


### PR DESCRIPTION
This allows sepolgen to generate policy from AVC messages that contain
contexts translated by mcstrans.

Fixes:

\# echo "type=USER_AVC msg=audit(1468415802.940:2199604): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0-s15:c0.c1023 msg='avc:  denied  { status } for auid=n/a uid=0 gid=0 cmdline="/usr/lib/systemd/systemd-logind" scontext=system_u:system_r:systemd_logind_t:SystemLow-SystemHigh tcontext=system_u:system_r:init_t:s0-s15:c0.c1023 tclass=system  exe="/usr/lib/systemd/systemd" sauid=0 hostname=? addr=? terminal=?'" | audit2allow

libsepol.mls_from_string: invalid MLS context SystemLow-SystemHigh
libsepol.mls_from_string: could not construct mls context structure
libsepol.context_from_record: could not create context structure
libsepol.context_from_string: could not create context structure
libsepol.sepol_context_to_sid: could not convert
system_u:system_r:systemd_logind_t:SystemLow-SystemHigh to sid

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>