### PR TITLE
libsemanage: do not change file mode of seusers and users_extra

### DIFF
--- a/libsemanage/src/direct_api.c
+++ b/libsemanage/src/direct_api.c
@@ -1481,7 +1481,7 @@ rebuild:
 			retval = semanage_copy_file(path,
 						    semanage_path(SEMANAGE_TMP,
 								  SEMANAGE_STORE_SEUSERS),
-						    sh->conf->file_mode);
+						    0);
 			if (retval < 0)
 				goto cleanup;
 			pseusers->dtable->drop_cache(pseusers->dbase);
@@ -1499,7 +1499,7 @@ rebuild:
 			retval = semanage_copy_file(path,
 						    semanage_path(SEMANAGE_TMP,
 								  SEMANAGE_USERS_EXTRA),
-						    sh->conf->file_mode);
+						    0);
 			if (retval < 0)
 				goto cleanup;
 			pusers_extra->dtable->drop_cache(pusers_extra->dbase);


### PR DESCRIPTION
Commit 8702a865e08b5660561e194a83e4a363061edc03 causes file mode of
seusers and users_extra to change based on the value defined in config
file whenever direct_commit is called and policy is not rebuilt.
(e.g. when setting a boolean).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1512639

$ ll /var/lib/selinux/targeted/active/users_extra
-rw-------. 1 root root 101 11. dub 17.31 /var/lib/selinux/targeted/active/users_extra
$ ll /var/lib/selinux/targeted/active/seusers
-rw-------. 1 root root 73 11. dub 17.31 /var/lib/selinux/targeted/active/seusers
$ semanage boolean -m --on httpd_can_network_connect
$ ll /var/lib/selinux/targeted/active/seusers
-rw-r--r--. 1 root root 73 23. bře 16.59 /var/lib/selinux/targeted/active/seusers
$ ll /var/lib/selinux/targeted/active/users_extra
-rw-r--r--. 1 root root 101 23. bře 16.59 /var/lib/selinux/targeted/active/users_extra
$ rpm -Vq selinux-policy-targeted
.M.....T.    /var/lib/selinux/targeted/active/seusers
.M.....T.    /var/lib/selinux/targeted/active/users_extra

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>