### PR TITLE
restorecond: Do not ignore the -f option

### DIFF
--- a/restorecond/restorecond.c
+++ b/restorecond/restorecond.c
@@ -148,6 +148,8 @@ int main(int argc, char **argv)
 	if (is_selinux_enabled() != 1)
 		return 0;
 
+	watch_file = server_watch_file;
+
 	/* Set all options to zero/NULL except for ignore_noent & digest. */
 	memset(&r_opts, 0, sizeof(r_opts));
 	r_opts.ignore_noent = SELINUX_RESTORECON_IGNORE_NOENTRY;
@@ -205,7 +207,6 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	watch_file = server_watch_file;
 	read_config(master_fd, watch_file);
 
 	if (!debug_mode) {


### PR DESCRIPTION
Since the default value of watch_file is set unconditionally *after* the
command-line arguments have been parsed, the -f option is (and has
always been) effectively ignored. Fix this by setting it before the
parsing.

Signed-off-by: Ondrej Mosnacek <omosnace@redhat.com>