### PR TITLE
libsemanage: improve semanage_migrate_store import failure

### DIFF
--- a/libsemanage/utils/semanage_migrate_store
+++ b/libsemanage/utils/semanage_migrate_store
@@ -15,7 +15,7 @@ sepol = ctypes.cdll.LoadLibrary('libsepol.so.1')
 try:
 	import selinux
 	import semanage
-except:
+except ImportError:
 	print("You must install libselinux-python and libsemanage-python before running this tool", file=sys.stderr)
 	exit(1)
 


### PR DESCRIPTION
The selinux/semanage python module import error in semanage_migrate_store
was misleading. Before, it would report that the selinux/semanage modules
were not installed even though they were on the system.

Now the import failure is only reported if the modules are not installed.
Otherwise, a stack trace is printed for all other errors in the selinux/semanage
python modules.

Signed-off-by: Yuli Khodorkovskiy <yuli.khodorkovskiy@crunchydata.com>