### PR TITLE
libsepol: Add ability to sort ocontexts in libsepol and add option to use it in checkpolicy

### DIFF
--- a/checkpolicy/checkpolicy.c
+++ b/checkpolicy/checkpolicy.c
@@ -111,9 +111,9 @@ unsigned int policyvers = POLICYDB_VERSION_MAX;
 static __attribute__((__noreturn__)) void usage(const char *progname)
 {
 	printf
-	    ("usage:  %s [-b[F]] [-C] [-d] [-U handle_unknown (allow,deny,reject)] [-M]"
-	     "[-c policyvers (%d-%d)] [-o output_file] [-t target_platform (selinux,xen)]"
-	     "[input_file]\n",
+	    ("usage:  %s [-b[F]] [-C] [-d] [-U handle_unknown (allow,deny,reject)] [-M] "
+	     "[-c policyvers (%d-%d)] [-o output_file] [-S] "
+	     "[-t target_platform (selinux,xen)] [input_file]\n",
 	     progname, POLICYDB_VERSION_MIN, POLICYDB_VERSION_MAX);
 	exit(1);
 }
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
 	size_t scontext_len, pathlen;
 	unsigned int i;
 	unsigned int protocol, port;
-	unsigned int binary = 0, debug = 0, cil = 0, conf = 0;
+	unsigned int binary = 0, debug = 0, sort = 0, cil = 0, conf = 0;
 	struct val_to_name v;
 	int ret, ch, fd, target = SEPOL_TARGET_SELINUX;
 	unsigned int nel, uret;
@@ -418,11 +418,12 @@ int main(int argc, char **argv)
 		{"mls", no_argument, NULL, 'M'},
 		{"cil", no_argument, NULL, 'C'},
 		{"conf",no_argument, NULL, 'F'},
+		{"sort", no_argument, NULL, 'S'},
 		{"help", no_argument, NULL, 'h'},
 		{NULL, 0, NULL, 0}
 	};
 
-	while ((ch = getopt_long(argc, argv, "o:t:dbU:MCFVc:h", long_options, NULL)) != -1) {
+	while ((ch = getopt_long(argc, argv, "o:t:dbU:MCFSVc:h", long_options, NULL)) != -1) {
 		switch (ch) {
 		case 'o':
 			outfile = optarg;
@@ -462,6 +463,9 @@ int main(int argc, char **argv)
 				break;
 			}
 			usage(argv[0]);
+		case 'S':
+			sort = 1;
+			break;
 		case 'M':
 			mlspol = 1;
 			break;
@@ -637,6 +641,14 @@ int main(int argc, char **argv)
 				policy_file_init(&pf);
 				pf.type = PF_USE_STDIO;
 				pf.fp = outfp;
+				if (sort) {
+					ret = policydb_sort_ocontexts(&policydb);
+					if (ret) {
+						fprintf(stderr, "%s:  error sorting ocontexts\n",
+						argv[0]);
+						exit(1);
+					}
+				}
 				ret = policydb_write(&policydb, &pf);
 			} else {
 				ret = sepol_kernel_policydb_to_conf(outfp, policydbp);

--- a/libsepol/include/sepol/policydb/policydb.h
+++ b/libsepol/include/sepol/policydb/policydb.h
@@ -640,6 +640,8 @@ extern void policydb_destroy(policydb_t * p);
 
 extern int policydb_load_isids(policydb_t * p, sidtab_t * s);
 
+extern int policydb_sort_ocontexts(policydb_t *p);
+
 /* Deprecated */
 extern int policydb_context_isvalid(const policydb_t * p,
 				    const context_struct_t * c);

--- a/libsepol/src/policydb.c
+++ b/libsepol/src/policydb.c
@@ -51,6 +51,7 @@
 #include <sepol/policydb/util.h>
 #include <sepol/policydb/flask.h>
 
+#include "kernel_to_common.h"
 #include "private.h"
 #include "debug.h"
 #include "mls.h"
@@ -4301,3 +4302,7 @@ int policydb_set_target_platform(policydb_t *p, int platform)
 	return 0;
 }
 
+int policydb_sort_ocontexts(policydb_t *p)
+{
+	return sort_ocontexts(p);
+}


### PR DESCRIPTION
ocontexts (initial sids, fs_use_*, genfscon, portcon, etc) are sorted by libsemanage when using policy modules and by libsepol when using CIL, but they are not sorted by checkpolicy when creating a policy from a policy.conf.

Checkpolicy's behavior allows control over the ordering which determines the matching order for portcons and other ocontext rules, but there are times when that specific control is not desired.

This patch set exposes an internal ocontext sorting function and adds a command line option to checkpolicy to sort ocontexts.


James Carter (2):
  libsepol: Create policydb_sort_ocontexts()
  checkpolicy: Add option to sort ocontexts when creating a binary
    policy

 checkpolicy/checkpolicy.c                  | 22 +++++++++++++++++-----
 libsepol/include/sepol/policydb/policydb.h |  2 ++
 libsepol/src/policydb.c                    |  5 +++++
 3 files changed, 24 insertions(+), 5 deletions(-)
