### PR TITLE
Fix snprintf truncated error

### DIFF
--- a/libsepol/src/kernel_to_cil.c
+++ b/libsepol/src/kernel_to_cil.c
@@ -536,7 +536,7 @@ static int write_sids_to_cil(FILE *out, const char *const *sid_to_str,
 	struct strs *strs;
 	char *sid;
 	char *prev;
-	char unknown[17];
+	char unknown[18];
 	unsigned i;
 	int rc;
 
@@ -550,7 +550,7 @@ static int write_sids_to_cil(FILE *out, const char *const *sid_to_str,
 		if (i < num_sids) {
 			sid = (char *)sid_to_str[i];
 		} else {
-			snprintf(unknown, 17, "%s%u", "UNKNOWN", i);
+			snprintf(unknown, 18, "%s%u", "UNKNOWN", i);
 			sid = strdup(unknown);
 		}
 		rc = strs_add_at_index(strs, sid, i);
@@ -2498,7 +2498,7 @@ static int write_sid_context_rules_to_cil(FILE *out, struct policydb *pdb, const
 	struct ocontext *isid;
 	struct strs *strs;
 	char *sid;
-	char unknown[17];
+	char unknown[18];
 	char *ctx, *rule;
 	unsigned i;
 	int rc = -1;
@@ -2513,7 +2513,7 @@ static int write_sid_context_rules_to_cil(FILE *out, struct policydb *pdb, const
 		if (i < num_sids) {
 			sid = (char *)sid_to_str[i];
 		} else {
-			snprintf(unknown, 17, "%s%u", "UNKNOWN", i);
+			snprintf(unknown, 18, "%s%u", "UNKNOWN", i);
 			sid = unknown;
 		}
 

--- a/libsepol/src/kernel_to_conf.c
+++ b/libsepol/src/kernel_to_conf.c
@@ -434,7 +434,7 @@ static int write_sids_to_conf(FILE *out, const char *const *sid_to_str,
 	struct ocontext *isid;
 	struct strs *strs;
 	char *sid;
-	char unknown[17];
+	char unknown[18];
 	unsigned i;
 	int rc;
 
@@ -448,7 +448,7 @@ static int write_sids_to_conf(FILE *out, const char *const *sid_to_str,
 		if (i < num_sids) {
 			sid = (char *)sid_to_str[i];
 		} else {
-			snprintf(unknown, 17, "%s%u", "UNKNOWN", i);
+			snprintf(unknown, 18, "%s%u", "UNKNOWN", i);
 			sid = strdup(unknown);
 		}
 		rc = strs_add_at_index(strs, sid, i);
@@ -2358,7 +2358,7 @@ static int write_sid_context_rules_to_conf(FILE *out, struct policydb *pdb, cons
 	struct ocontext *isid;
 	struct strs *strs;
 	char *sid;
-	char unknown[17];
+	char unknown[18];
 	char *ctx, *rule;
 	unsigned i;
 	int rc;
@@ -2373,7 +2373,7 @@ static int write_sid_context_rules_to_conf(FILE *out, struct policydb *pdb, cons
 		if (i < num_sids) {
 			sid = (char *)sid_to_str[i];
 		} else {
-			snprintf(unknown, 17, "%s%u", "UNKNOWN", i);
+			snprintf(unknown, 18, "%s%u", "UNKNOWN", i);
 			sid = unknown;
 		}
 

--- a/libsepol/src/module_to_cil.c
+++ b/libsepol/src/module_to_cil.c
@@ -2562,7 +2562,7 @@ static int ocontext_isid_to_cil(struct policydb *pdb, const char *const *sid_to_
 	struct sid_item *head = NULL;
 	struct sid_item *item = NULL;
 	char *sid;
-	char unknown[17];
+	char unknown[18];
 	unsigned i;
 
 	for (isid = isids; isid != NULL; isid = isid->next) {
@@ -2570,7 +2570,7 @@ static int ocontext_isid_to_cil(struct policydb *pdb, const char *const *sid_to_
 		if (i < num_sids) {
 			sid = (char*)sid_to_string[i];
 		} else {
-			snprintf(unknown, 17, "%s%u", "UNKNOWN", i);
+			snprintf(unknown, 18, "%s%u", "UNKNOWN", i);
 			sid = unknown;
 		}
 		cil_println(0, "(sid %s)", sid);


### PR DESCRIPTION
Fix some error with `snprintf(unknown, 17, "%s%u", "UNKNOWN", i);`