### PR TITLE
mcstrans: remove unused getpeercon_raw() call

### DIFF
--- a/mcstrans/src/mcstransd.c
+++ b/mcstrans/src/mcstransd.c
@@ -142,17 +142,8 @@ process_request(int fd, uint32_t function, char *data1, char *UNUSED(data2))
 {
 	int32_t result;
 	char *out = NULL;
-	char *peercon = NULL;
 	int ret;
 
-	ret = getpeercon_raw(fd, &peercon);
-	if (ret < 0)
-		return ret;
-
-	/* TODO: Check if MLS clearance (in peercon) dominates the MLS label
-	 * (in the request input).
-	 */
-  
 	switch (function) {
 	case SETRANS_INIT:
 		result = 0;
@@ -184,7 +175,6 @@ process_request(int fd, uint32_t function, char *data1, char *UNUSED(data2))
 	}
 
 	free(out);
-	freecon(peercon);
 
 	return ret;
 }


### PR DESCRIPTION
There is a call to getpeercon_raw() in mcstransd, but nothing is done
with the context. The purpose of process_request() is to translate a
context and we would like that to succeed even if, for some reason,
getpeercon_raw() fails.

Signed-off-by: Yuli Khodorkovskiy <yuli@crunchydata.com>
Signed-off-by: Joshua Brindle <joshua.brindle@crunchydata.com>