### PR TITLE
libselinux: fix overly strict validation of file_contexts.bin

### DIFF
--- a/libselinux/src/label_file.c
+++ b/libselinux/src/label_file.c
@@ -232,7 +232,7 @@ end_arch_check:
 
 	/* allocate the stems_data array */
 	rc = next_entry(&stem_map_len, mmap_area, sizeof(uint32_t));
-	if (rc < 0 || !stem_map_len)
+	if (rc < 0)
 		return -1;
 
 	/*

--- a/libselinux/src/regex.c
+++ b/libselinux/src/regex.c
@@ -348,7 +348,7 @@ int regex_load_mmap(struct mmap_area *mmap_area, struct regex_data **regex,
 		goto err;
 
 	rc = next_entry(&entry_len, mmap_area, sizeof(uint32_t));
-	if (rc < 0 || !entry_len)
+	if (rc < 0)
 		goto err;
 
 	if (entry_len) {


### PR DESCRIPTION
load_mmap and regex_load_mmap (in the !USE_PCRE2 case) were
incorrectly treating the absence of any fixed stems or study data
as an error, rejecting valid file_contexts.bin files.  Remove
the extraneous validation checks.

Test:
$ cat > file_contexts <<EOF
(/.*)?                u:object_r:system_file:s0
/lib                   u:object_r:system_dir:s0
EOF
$ sefcontext_compile file_contexts
$ selabel_lookup -b file -k /lib -f file_contexts.bin

Before:
ERROR: selabel_open - Could not obtain handle.

After:
Default context: u:object_r:system_dir:s0

Reported-by: Jiyong Park <jiyong@google.com>
Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>