### PR TITLE
dbus: remove deprecated at_console statement

### DIFF
--- a/dbus/org.selinux.conf
+++ b/dbus/org.selinux.conf
@@ -12,12 +12,8 @@
 
   <!-- Allow anyone to invoke methods on the interfaces,
        authorization is performed by PolicyKit -->
-  <policy at_console="true">
-    <allow send_destination="org.selinux"/>
-  </policy>
   <policy context="default">
-    <allow send_destination="org.selinux"
-	   send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="org.selinux"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
As described in [0], this likely did not have the intended effect, so
simply remove it. The change in behavior is that up until this patch
it would be possible for any non-system user to potentially gain access
to selinux' dbus interface. Now this is extended to also allow any
system user.

As the comment indicates, PolicyKit is used to enforce access, so this
should be perfectly harmless.

[0]: <https://www.spinics.net/lists/linux-bluetooth/msg75267.html>

Signed-off-by: Tom Gundersen <teg@jklm.no>
CC: David Herrmann <dh.herrmann@gmail.com>