### PR TITLE
python/restorecon: add force option

### DIFF
--- a/libselinux/src/selinuxswig_python.i
+++ b/libselinux/src/selinuxswig_python.i
@@ -20,7 +20,7 @@ DISABLED = -1
 PERMISSIVE = 0
 ENFORCING = 1
 
-def restorecon(path, recursive=False, verbose=False):
+def restorecon(path, recursive=False, verbose=False, force=False):
     """ Restore SELinux context on a given path
 
     Arguments:
@@ -29,6 +29,9 @@ def restorecon(path, recursive=False, verbose=False):
     Keyword arguments:
     recursive -- Change files and directories file labels recursively (default False)
     verbose -- Show changes in file labels (default False)
+    force -- Force reset of context to match file_context for customizable files,
+    and the default file context, changing the user, role, range portion  as well
+    as the type (default False)
     """
 
     restorecon_flags = SELINUX_RESTORECON_IGNORE_DIGEST | SELINUX_RESTORECON_REALPATH
@@ -36,6 +39,8 @@ def restorecon(path, recursive=False, verbose=False):
         restorecon_flags |= SELINUX_RESTORECON_RECURSE
     if verbose:
         restorecon_flags |= SELINUX_RESTORECON_VERBOSE
+    if force:
+        restorecon_flags |= SELINUX_RESTORECON_SET_SPECFILE_CTX
     selinux_restorecon(os.path.expanduser(path), restorecon_flags)
 
 def chcon(path, context, recursive=False):


### PR DESCRIPTION
This adds 'force' keyword argument to selinux.restorecon() function
using SELINUX_RESTORECON_SET_SPECFILE_CTX flag similar to -F option in restorecon util.