### PR TITLE
Run python tests with "make test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,16 @@ addons:
     - xmlto
 
 install:
-  # Download refpolicy Makefile for sepolgen tests
-  - sudo mkdir -p /usr/share/selinux/default
-  - sudo curl --retry 10 -o /usr/share/selinux/default/Makefile 'https://raw.githubusercontent.com/SELinuxProject/refpolicy/RELEASE_2_20180114/support/Makefile.devel'
-  - sudo sed "s,^PREFIX :=.*,PREFIX := $TRAVIS_BUILD_DIR/installdir/usr," -i /usr/share/selinux/default/Makefile
-  - sudo mkdir -p /usr/share/selinux/refpolicy/include
-  - sudo curl --retry 10 -o /usr/share/selinux/refpolicy/include/build.conf 'https://raw.githubusercontent.com/SELinuxProject/refpolicy/RELEASE_2_20180114/build.conf'
+  # Download and install refpolicy headers for sepolgen tests
+  - curl --location --retry 10 -o "$TRAVIS_BUILD_DIR/refpolicy.tar.bz2" https://github.com/SELinuxProject/refpolicy/releases/download/RELEASE_2_20180701/refpolicy-2.20180701.tar.bz2
+  - tar -C "$TRAVIS_BUILD_DIR" -xvjf "$TRAVIS_BUILD_DIR/refpolicy.tar.bz2"
+  # Make refpolicy Makefile use the new toolchain when building modules
+  - sed -e "s,^PREFIX :=.*,PREFIX := \$(DESTDIR)/usr," -i "$TRAVIS_BUILD_DIR/refpolicy/support/Makefile.devel"
+  - sudo make -C "$TRAVIS_BUILD_DIR/refpolicy" install-headers
+  - sudo rm -rf "$TRAVIS_BUILD_DIR/refpolicy.tar.bz2" "$TRAVIS_BUILD_DIR/refpolicy"
   - sudo mkdir -p /etc/selinux
   - echo 'SELINUXTYPE=refpolicy' | sudo tee /etc/selinux/config
+  - echo 'SELINUX_DEVEL_PATH = /usr/share/selinux/refpolicy' | sudo tee /etc/selinux/sepolgen.conf
 
   # Make sepolgen tests work without really installing anything in the real root (doing this would conflict with Ubuntu packages)
   - sed -e "s,\"\(/usr/bin/[cs]\),\"$TRAVIS_BUILD_DIR/installdir\1," -i python/sepolgen/src/sepolgen/module.py

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,8 +1,6 @@
 SUBDIRS = sepolicy audit2allow semanage sepolgen chcat
 
-all install relabel clean indent:
+all install relabel clean indent test:
 	@for subdir in $(SUBDIRS); do \
 		(cd $$subdir && $(MAKE) $@) || exit 1; \
 	done
-
-test:

--- a/python/audit2allow/.gitignore
+++ b/python/audit2allow/.gitignore
@@ -1,1 +1,2 @@
 sepolgen-ifgen-attr-helper
+test_dummy_policy

--- a/python/audit2allow/Makefile
+++ b/python/audit2allow/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= python
+SECILC ?= secilc
 
 # Installation directories.
 PREFIX ?= /usr
@@ -22,8 +23,11 @@ sepolgen-ifgen-attr-helper: sepolgen-ifgen-attr-helper.o $(LIBSEPOLA)
 audit2why:
 	ln -sf audit2allow audit2why
 
-test: all
+test: all test_dummy_policy
 	@$(PYTHON) test_audit2allow.py -v
+
+test_dummy_policy: test_dummy_policy.cil
+	$(SECILC) -o $@ -f /dev/null $<
 
 install: all
 	-mkdir -p $(DESTDIR)$(BINDIR)
@@ -36,7 +40,7 @@ install: all
 	install -m 644 audit2why.1 $(DESTDIR)$(MANDIR)/man1/
 
 clean:
-	rm -f *~ *.o sepolgen-ifgen-attr-helper
+	rm -f *~ *.o sepolgen-ifgen-attr-helper test_dummy_policy
 
 indent:
 	../../scripts/Lindent $(wildcard *.[ch])

--- a/python/audit2allow/audit2allow
+++ b/python/audit2allow/audit2allow
@@ -242,7 +242,10 @@ class AuditToPolicy:
 
     def __output_audit2why(self):
         import selinux
-        import sepolicy
+        try:
+            import sepolicy
+        except (ImportError, ValueError):
+            sepolicy = None
         for i in self.__parser.avc_msgs:
             rc = i.type
             data = i.data
@@ -262,11 +265,13 @@ class AuditToPolicy:
                 if len(data) > 1:
                     print("\tOne of the following booleans was set incorrectly.")
                     for b in data:
-                        print("\tDescription:\n\t%s\n" % sepolicy.boolean_desc(b[0]))
+                        if sepolicy is not None:
+                            print("\tDescription:\n\t%s\n" % sepolicy.boolean_desc(b[0]))
                         print("\tAllow access by executing:\n\t# setsebool -P %s %d" % (b[0], b[1]))
                 else:
                     print("\tThe boolean %s was set incorrectly. " % (data[0][0]))
-                    print("\tDescription:\n\t%s\n" % sepolicy.boolean_desc(data[0][0]))
+                    if sepolicy is not None:
+                        print("\tDescription:\n\t%s\n" % sepolicy.boolean_desc(data[0][0]))
                     print("\tAllow access by executing:\n\t# setsebool -P %s %d" % (data[0][0], data[0][1]))
                 continue
 

--- a/python/audit2allow/sepolgen-ifgen
+++ b/python/audit2allow/sepolgen-ifgen
@@ -56,6 +56,8 @@ def parse_options():
                       help="print debuging output")
     parser.add_option("-d", "--debug", action="store_true", default=False,
                       help="extra debugging output")
+    parser.add_option("--attr-helper", default=ATTR_HELPER,
+                      help="path to sepolgen-ifgen-attr-helper")
     parser.add_option("--no_attrs", action="store_true", default=False,
                       help="do not retrieve attribute access from kernel policy")
     options, args = parser.parse_args()
@@ -77,7 +79,7 @@ def get_policy():
     return None
 
 
-def get_attrs(policy_path):
+def get_attrs(policy_path, attr_helper):
     try:
         if not policy_path:
             policy_path = get_policy()
@@ -93,7 +95,7 @@ def get_attrs(policy_path):
         return None
 
     fd = open("/dev/null", "w")
-    ret = subprocess.Popen([ATTR_HELPER, policy_path, outfile.name], stdout=fd).wait()
+    ret = subprocess.Popen([attr_helper, policy_path, outfile.name], stdout=fd).wait()
     fd.close()
     if ret != 0:
         sys.stderr.write("could not run attribute helper\n")
@@ -127,7 +129,7 @@ def main():
     # Get the attibutes from the binary
     attrs = None
     if not options.no_attrs:
-        attrs = get_attrs(options.policy_path)
+        attrs = get_attrs(options.policy_path, options.attr_helper)
         if attrs is None:
             return 1
 

--- a/python/audit2allow/sepolgen-ifgen
+++ b/python/audit2allow/sepolgen-ifgen
@@ -96,7 +96,7 @@ def get_attrs(policy_path):
     ret = subprocess.Popen([ATTR_HELPER, policy_path, outfile.name], stdout=fd).wait()
     fd.close()
     if ret != 0:
-        sys.stderr.write("could not run attribute helper")
+        sys.stderr.write("could not run attribute helper\n")
         return None
 
     attrs = interfaces.AttributeSet()

--- a/python/audit2allow/sepolgen-ifgen
+++ b/python/audit2allow/sepolgen-ifgen
@@ -135,8 +135,7 @@ def main():
     try:
         headers = refparser.parse_headers(options.headers, output=log, debug=options.debug)
     except ValueError as e:
-        print("error parsing headers")
-        print(str(e))
+        sys.stderr.write("error parsing headers: %s\n" % e)
         return 1
 
     if_set = interfaces.InterfaceSet(output=log)

--- a/python/audit2allow/test_audit2allow.py
+++ b/python/audit2allow/test_audit2allow.py
@@ -28,7 +28,10 @@ class Audit2allowTests(unittest.TestCase):
         "Verify sepolgen-ifgen works"
         temp_directory = mkdtemp(suffix='audit2allow_test')
         output_file = os.path.join(temp_directory, 'interface_info')
-        p = Popen([sys.executable, './sepolgen-ifgen', '-p', 'test_dummy_policy', '-o', output_file], stdout=PIPE)
+        p = Popen([
+            sys.executable, './sepolgen-ifgen', '-p', 'test_dummy_policy', '-o', output_file,
+            '--attr-helper', './sepolgen-ifgen-attr-helper'
+            ], stdout=PIPE)
         out, err = p.communicate()
         if err:
             print(out, err)

--- a/python/audit2allow/test_dummy_policy.cil
+++ b/python/audit2allow/test_dummy_policy.cil
@@ -1,0 +1,75 @@
+; This is a dummy policy which main aim is to be compatible with test.log
+
+; Define one category and one sensitivity in order to make things work
+(mls true)
+(category c0)
+(categoryorder (c0))
+(sensitivity s0)
+(sensitivityorder (s0))
+(sensitivitycategory s0 (c0))
+
+; Define some users and roles
+(user system_u)
+(user root)
+(user unconfined_u)
+(role system_r)
+(role unconfined_r)
+(userrole root system_r)
+(userrole system_u system_r)
+(userrole unconfined_u unconfined_r)
+(userlevel system_u (s0))
+(userlevel root (s0))
+(userlevel unconfined_u (s0))
+(userrange system_u ((s0)(s0 (c0))))
+(userrange root ((s0)(s0 (c0))))
+(userrange unconfined_u ((s0)(s0 (c0))))
+
+; Define domain types
+(type automount_t)
+(type ftpd_t)
+(type httpd_t)
+(type kernel_t)
+(type nsplugin_t)
+(type postfix_local_t)
+(type qemu_t)
+(type smbd_t)
+
+(roletype system_r automount_t)
+(roletype system_r ftpd_t)
+(roletype system_r httpd_t)
+(roletype system_r kernel_t)
+(roletype system_r postfix_local_t)
+(roletype system_r qemu_t)
+(roletype system_r smbd_t)
+(roletype unconfined_r nsplugin_t)
+
+; Define file types
+(type automount_lock_t)
+(type default_t)
+(type fixed_disk_device_t)
+(type home_root_t)
+(type httpd_sys_content_t)
+(type httpd_sys_script_exec_t)
+(type mail_spool_t)
+(type ssh_home_t)
+(type usr_t)
+(type var_t)
+
+; Define port types
+(type mysqld_port_t)
+(type reserved_port_t)
+
+; Define initial SID
+(sid kernel)
+(sidorder (kernel))
+(sidcontext kernel (system_u system_r kernel_t ((s0) (s0))))
+
+; Define classes
+(class blk_file (getattr open read write))
+(class dir (append open search))
+(class file (execute execute_no_trans getattr open read write))
+(class tcp_socket (ioctl name_bind name_connect))
+(classorder (blk_file file dir tcp_socket))
+
+; The policy compiler requires at least one rule
+(allow kernel_t default_t (file (open read write)))

--- a/python/chcat/Makefile
+++ b/python/chcat/Makefile
@@ -17,3 +17,5 @@ clean:
 indent:
 
 relabel:
+
+test:

--- a/python/semanage/semanage
+++ b/python/semanage/semanage
@@ -83,6 +83,7 @@ class CheckRole(argparse.Action):
         if not newval:
             newval = []
         try:
+            # sepolicy tries to load the SELinux policy and raises ValueError if it fails.
             import sepolicy
             roles = sepolicy.get_all_roles()
         except ValueError:

--- a/python/sepolgen/src/sepolgen/defaults.py
+++ b/python/sepolgen/src/sepolgen/defaults.py
@@ -32,12 +32,13 @@ class PathChooser(object):
         self.config_pathname = pathname
         ignore = re.compile(r"^\s*(?:#.+)?$")
         consider = re.compile(r"^\s*(\w+)\s*=\s*(.+?)\s*$")
-        for lineno, line in enumerate(open(pathname)):
-            if ignore.match(line): continue
-            mo = consider.match(line)
-            if not mo:
-                raise ValueError("%s:%d: line is not in key = value format" % (pathname, lineno+1))
-            self.config[mo.group(1)] = mo.group(2)
+        with open(pathname, "r") as fd:
+            for lineno, line in enumerate(fd):
+                if ignore.match(line): continue
+                mo = consider.match(line)
+                if not mo:
+                    raise ValueError("%s:%d: line is not in key = value format" % (pathname, lineno+1))
+                self.config[mo.group(1)] = mo.group(2)
 
     # We're only exporting one useful function, so why not be a function
     def __call__(self, testfilename, pathset="SELINUX_DEVEL_PATH"):

--- a/python/sepolgen/src/sepolgen/defaults.py
+++ b/python/sepolgen/src/sepolgen/defaults.py
@@ -70,7 +70,10 @@ def attribute_info():
 
 def refpolicy_makefile():
     chooser = PathChooser("/etc/selinux/sepolgen.conf")
-    return chooser("Makefile")
+    result = chooser("Makefile")
+    if not os.path.exists(result):
+        result = chooser("include/Makefile")
+    return result
 
 def headers():
     chooser = PathChooser("/etc/selinux/sepolgen.conf")

--- a/scripts/run-flake8
+++ b/scripts/run-flake8
@@ -4,6 +4,11 @@
 # Run on the base directory if no argument has been given
 if [ $# -eq 0 ] ; then
     cd "$(dirname -- "$0")/.." || exit $?
+
+    # Run on both files ending with .py and Python files without extension
+    # shellcheck disable=SC2046
+    set -- $( (find . -name '*.py' ; grep --exclude-dir=.git -l -e '^#!\s*/usr/bin/python' -e '^#!/usr/bin/env python' -r .) | sort -u )
+    echo "Analyzing $# Python scripts"
 fi
 
 # Assign each ignore warning on a line, in order to ease testing enabling the warning again


### PR DESCRIPTION
Currently, executing `make test` from the root directory of the project does not go into `python/`. This pull request fixes this, by making audit2allow testsuite executable by a non-privileged user.

I have already sent half of the patches on the mailing list (https://lore.kernel.org/selinux/20181221204333.27445-1-nicolas.iooss@m4x.org/T/) and will send the other half now.