### PR TITLE
libsemanage: set selinux policy root around calls to selinux_boolean_sub

### DIFF
--- a/libsemanage/src/handle.c
+++ b/libsemanage/src/handle.c
@@ -58,6 +58,8 @@ const char * semanage_root(void)
 	return private_semanage_root;
 }
 
+hidden_def(semanage_root);
+
 semanage_handle_t *semanage_handle_create(void)
 {
 	semanage_handle_t *sh = NULL;

--- a/libsemanage/src/handle_internal.h
+++ b/libsemanage/src/handle_internal.h
@@ -5,8 +5,9 @@
 #include "dso.h"
 
 hidden_proto(semanage_begin_transaction)
-    hidden_proto(semanage_handle_destroy)
-    hidden_proto(semanage_reload_policy)
-    hidden_proto(semanage_access_check)
-    hidden_proto(semanage_set_root)
+hidden_proto(semanage_handle_destroy)
+hidden_proto(semanage_reload_policy)
+hidden_proto(semanage_access_check)
+hidden_proto(semanage_set_root)
+hidden_proto(semanage_root)
 #endif


### PR DESCRIPTION
As reported in #109, semodule -p /path/to/policyroot -s minimum -n -B
tries to use /etc/selinux/targeted/booleans.subs_dist.  This is because
it invokes the libselinux selinux_boolean_sub() interface, which uses
the active/installed policy files rather than the libsemanage ones.

Switch the selinux policy root around the selinux_boolean_sub() call
to incorporate the semanage root as a prefix and to use the specified
policy store as a suffix so that the correct booleans.subs_dist file
(if any) is used.

The underlying bug is that booleans.subs_dist is not itself managed
via libsemanage. If it was managed and therefore lived within the
policy store, then libsemanage could access the appropriate
booleans.subs_dist file without using the libselinux interface at all,
and thus would not need to modify the selinux policy root.  Moving
booleans.subs_dist to a managed file is deferred to a future change.

Test:
strace semodule -p ~/policy-root -s minimum -n -B

Before:
openat(AT_FDCWD, "/etc/selinux/targeted/booleans.subs_dist", O_RDONLY|O_CLOEXEC) = 5

After:
openat(AT_FDCWD, "/home/sds/policy-root/etc/selinux/minimum/booleans.subs_dist", O_RDONLY|O_CLOEXEC) = 5

Fixes https://github.com/SELinuxProject/selinux/issues/109

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>