### PR TITLE
scripts/run-flake8: run on Python scripts not ending with .py

### DIFF
--- a/scripts/run-flake8
+++ b/scripts/run-flake8
@@ -4,6 +4,11 @@
 # Run on the base directory if no argument has been given
 if [ $# -eq 0 ] ; then
     cd "$(dirname -- "$0")/.." || exit $?
+
+    # Run on both files ending with .py and Python files without extension
+    # shellcheck disable=SC2046
+    set -- $( (find . -name '*.py' ; grep --exclude-dir=.git -l -e '^#!\s*/usr/bin/python' -e '^#!/usr/bin/env python' -r .) | sort -u )
+    echo "Analyzing $# Python scripts"
 fi
 
 # Assign each ignore warning on a line, in order to ease testing enabling the warning again


### PR DESCRIPTION
When running flake8 on a directory, it does not analyze files without an
extension, like semanage_migrate_store, mlscolor-test, etc. Use grep to
find files with a Python shebang and build a list which is then given to
flake8.

This commit is possible now that some clean-up patches have been
applied, such as commit 69c56bd2f6e9 ("python/chcat: improve the code
readability") and b7227aaec1da ("mcstrans: fix Python linter warnings on
test scripts") and 3cb974d2d2a7 ("semanage_migrate_store: fix many
Python linter warnings").

Signed-off-by: Nicolas Iooss <nicolas.iooss@m4x.org>