### PR TITLE
libselinux/audit2why.so: Filter out non-python related symbols

### DIFF
--- a/libselinux/src/Makefile
+++ b/libselinux/src/Makefile
@@ -165,7 +165,7 @@ $(AUDIT2WHYLOBJ): audit2why.c
 	$(CC) $(filter-out -Werror, $(CFLAGS)) $(PYINC) -fPIC -DSHARED -c -o $@ $<
 
 $(AUDIT2WHYSO): $(AUDIT2WHYLOBJ) $(LIBSEPOLA)
-	$(CC) $(CFLAGS) $(LDFLAGS) -L. -shared -o $@ $^ -lselinux $(LDLIBS_LIBSEPOLA) $(PYLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -L. -shared -o $@ $^ -lselinux $(LDLIBS_LIBSEPOLA) $(PYLIBS) -Wl,-soname,audit2why.so,--version-script=audit2why.map,-z,defs
 
 %.o:  %.c policy.h
 	$(CC) $(CFLAGS) $(TLSFLAGS) -c -o $@ $<

--- a/libselinux/src/audit2why.map
+++ b/libselinux/src/audit2why.map
@@ -1,0 +1,6 @@
+AUDIT2WHY_2.9 {
+  global:
+    initaudit2why;
+    PyInit_audit2why;
+  local: *;
+};


### PR DESCRIPTION
audit2why.so used to export libsepol.a symbols. We only need Python related
symbols:

- initaudit2why for python 2
- PyInit_audit2why for python3

Signed-off-by: Petr Lautrbach <plautrba@redhat.com>