### PR TITLE
More robust ausearch time input

### DIFF
--- a/python/sepolicy/sepolicy/templates/script.py
+++ b/python/sepolicy/sepolicy/templates/script.py
@@ -34,8 +34,9 @@ fi
 
 if [ $# -eq 1 ]; then
 	if [ "$1" = "--update" ] ; then
-		time=`ls -l --time-style="+%x %X" TEMPLATEFILE.te | awk '{ printf "%s %s", $6, $7 }'`
-		rules=`ausearch --start $time -m avc --raw -se TEMPLATETYPE`
+		time=`date -r TEMPLATETYPE.te "+%x"`
+                date=`date -r TEMPLATETYPE.te "+%X"`
+                rules=`ausearch --start "$time" "$date" -m avc --raw -se TEMPLATETYPE`
 		if [ x"$rules" != "x" ] ; then
 			echo "Found avc's to update policy with"
 			echo -e "$rules" | audit2allow -R


### PR DESCRIPTION
Depending on what locale you were using, you may have time that would show AM or PM.
This would cause the time to be incorrect on noon and midnight rollovers. This change allows
all the output of strptime's %x and %X to be captured and provided to ausearch.