### PR TITLE
Restorecon: factor out a lookup helper for context matches

### DIFF
--- a/libselinux/include/selinux/label.h
+++ b/libselinux/include/selinux/label.h
@@ -7,6 +7,7 @@
 #define _SELABEL_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <selinux/selinux.h>
 
@@ -104,6 +105,9 @@ int selabel_lookup_raw(struct selabel_handle *handle, char **con,
 		       const char *key, int type);
 
 bool selabel_partial_match(struct selabel_handle *handle, const char *key);
+
+bool selabel_hash_all_partial_matches(struct selabel_handle *rec,
+                                      const char *key, uint8_t* digest);
 
 int selabel_lookup_best_match(struct selabel_handle *rec, char **con,
 			      const char *key, const char **aliases, int type);

--- a/libselinux/src/label.c
+++ b/libselinux/src/label.c
@@ -274,6 +274,15 @@ bool selabel_partial_match(struct selabel_handle *rec, const char *key)
 	return rec->func_partial_match(rec, key);
 }
 
+bool selabel_hash_all_partial_matches(struct selabel_handle *rec,
+                                      const char *key, uint8_t *digest) {
+	if (!rec->func_hash_all_partial_matches) {
+		return false;
+	}
+
+	return rec->func_hash_all_partial_matches(rec, key, digest);
+}
+
 int selabel_lookup_best_match(struct selabel_handle *rec, char **con,
 			      const char *key, const char **aliases, int type)
 {

--- a/libselinux/src/label_internal.h
+++ b/libselinux/src/label_internal.h
@@ -87,6 +87,8 @@ struct selabel_handle {
 	void (*func_close) (struct selabel_handle *h);
 	void (*func_stats) (struct selabel_handle *h);
 	bool (*func_partial_match) (struct selabel_handle *h, const char *key);
+	bool (*func_hash_all_partial_matches) (struct selabel_handle *h,
+	                                       const char *key, uint8_t *digest);
 	struct selabel_lookup_rec *(*func_lookup_best_match)
 						    (struct selabel_handle *h,
 						    const char *key,


### PR DESCRIPTION
We used to hash the file_context and skip the restorecon on the top
level directory if the hash doesn't change. But the file_context might
change after an update; and some users experienced long restorecon
time as they have lots of files under directories like /data/media.
Therefore, we try to skip unnecessary restores if the file context
relates to the given directory doesn't change.

This CL is the first step that factors out a lookup helper function
and returns an array of matched pointers instead of a single one.
The old loopup_common function is then modified to take the first
element in the array.

This change has already been submitted in android selinux branch. And
porting it upstream will make these two branches more consistent and
save some work for the future merges.

Signed-off-by: Tianjie Xu <xunchang@google.com>