### PR TITLE
restorecond: Do not link against libpcre

### DIFF
--- a/restorecond/Makefile
+++ b/restorecond/Makefile
@@ -19,17 +19,7 @@ DBUSLIB = $(shell $(PKG_CONFIG) --libs dbus-glib-1)
 CFLAGS ?= -g -Werror -Wall -W
 override CFLAGS += $(DBUSFLAGS)
 
-USE_PCRE2 ?= n
-ifeq ($(USE_PCRE2),y)
-	PCRE_CFLAGS := -DUSE_PCRE2 -DPCRE2_CODE_UNIT_WIDTH=8 $(shell $(PKG_CONFIG) --cflags libpcre2-8)
-	PCRE_LDLIBS := $(shell $(PKG_CONFIG) --libs libpcre2-8)
-else
-	PCRE_CFLAGS := $(shell $(PKG_CONFIG) --cflags libpcre)
-	PCRE_LDLIBS := $(shell $(PKG_CONFIG) --libs libpcre)
-endif
-export PCRE_CFLAGS PCRE_LDLIBS
-
-override LDLIBS += -lselinux $(PCRE_LDLIBS) $(DBUSLIB)
+override LDLIBS += -lselinux $(DBUSLIB)
 
 all: restorecond
 


### PR DESCRIPTION
For some reasons, restorecond was explicitly linking against libpcre but
the code is not using any of its symbols

Closes: https://github.com/SELinuxProject/selinux/issues/137