### PR TITLE
checkmodule: allow specifying module policy version

### DIFF
--- a/checkpolicy/checkmodule.8
+++ b/checkpolicy/checkmodule.8
@@ -38,7 +38,7 @@ Generate a non-base policy module.
 Enable the MLS/MCS support when checking and compiling the policy module.
 .TP
 .B \-V,\-\-version
- Show policy versions created by this program.  Note that you cannot currently build older versions.
+Show policy versions created by this program.
 .TP
 .B \-o,\-\-output filename
 Write a binary policy module file to the specified filename.
@@ -47,6 +47,9 @@ and will not generate a binary module at all.
 .TP
 .B \-U,\-\-handle-unknown <action>
 Specify how the kernel should handle unknown classes or permissions (deny, allow or reject).
+.TP
+.B \-c policyvers
+Specify the policy version, defaults to the latest.
 
 .SH EXAMPLE
 .nf

--- a/checkpolicy/checkmodule.c
+++ b/checkpolicy/checkmodule.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 		{NULL, 0, NULL, 0}
 	};
 
-	while ((ch = getopt_long(argc, argv, "ho:bVU:mMC", long_options, NULL)) != -1) {
+	while ((ch = getopt_long(argc, argv, "ho:bVU:mMCc:", long_options, NULL)) != -1) {
 		switch (ch) {
 		case 'h':
 			usage(argv[0]);
@@ -194,7 +194,6 @@ int main(int argc, char **argv)
 			usage(argv[0]);
 		case 'm':
 			policy_type = POLICY_MOD;
-			policyvers = MOD_POLICYDB_VERSION_MAX;
 			break;
 		case 'M':
 			mlspol = 1;
@@ -202,6 +201,30 @@ int main(int argc, char **argv)
 		case 'C':
 			cil = 1;
 			break;
+		case 'c': {
+			long int n;
+			errno = 0;
+			n = strtol(optarg, NULL, 10);
+
+			if (errno) {
+				fprintf(stderr,
+					"Invalid policyvers specified: %s\n",
+					optarg);
+				usage(argv[0]);
+			}
+
+			if (n < MOD_POLICYDB_VERSION_MIN
+			    || n > MOD_POLICYDB_VERSION_MAX) {
+				fprintf(stderr,
+					"policyvers value %ld not in range %d-%d\n",
+					n, MOD_POLICYDB_VERSION_MIN,
+					MOD_POLICYDB_VERSION_MAX);
+				usage(argv[0]);
+			}
+
+			policyvers = n;
+			break;
+		}
 		default:
 			usage(argv[0]);
 		}

--- a/checkpolicy/checkmodule.c
+++ b/checkpolicy/checkmodule.c
@@ -142,6 +142,8 @@ static __attribute__((__noreturn__)) void usage(const char *progname)
 	printf("  -m         build a policy module instead of a base module\n");
 	printf("  -M         enable MLS policy\n");
 	printf("  -o FILE    write module to FILE (else just check syntax)\n");
+	printf("  -c VERSION build a policy module targeting a modular policy version (%d-%d)\n",
+		MOD_POLICYDB_VERSION_MIN, MOD_POLICYDB_VERSION_MAX);
 	exit(1);
 }
 

--- a/checkpolicy/test/dismod.c
+++ b/checkpolicy/test/dismod.c
@@ -903,14 +903,14 @@ int main(int argc, char **argv)
 	}
 
 	if (policydb.policy_type == POLICY_BASE) {
-		printf("Binary base policy file loaded.\n\n");
+		printf("Binary base policy file loaded.\n");
 	} else {
 		printf("Binary policy module file loaded.\n");
 		printf("Module name: %s\n", policydb.name);
 		printf("Module version: %s\n", policydb.version);
-		printf("\n");
 	}
 
+	printf("Policy version: %d\n\n", policydb.policyvers);
 	menu();
 	for (;;) {
 		printf("\nCommand (\'m\' for menu):  ");


### PR DESCRIPTION
Currently checkpolicy can produce binary policies for earlier policy versions
to provide support for building policies on one machine and loading/analyzing
them on another machine with an earlier version of the kernel or libsepol,
respectively. However, checkmodule was lacking this capability.
    
This commit adds an identical `-c` flag that can be passed to checkmodule that
will build a modular policy file of the specified version.

Additionally, I updated dismod to display the policy version since there was no way to get at this information without debug logging in the userspace tools (that I know of).

```
> $ cat > test.te <<EOF
module test 1.0;

require {
    type domain;
    type file_type;
    class file { read write };
}

allow domain file_type : file { read write };
EOF
> $ obj/usr/bin/checkmodule -m -M -c 10 -o test.mod test.te
> $ checkpolicy/test/dismod test.mod
Reading policy...
... snip ...
Binary policy module file loaded.
Module name: test
Module version: 1.0
Policy version: 10
```

This patch relates to an issue that was reported by a user in the #selinux Freenode IRC channel who had a later version of libsepol on the machine that was building their policy modules.