### PR TITLE
Global replace exit(0) with more readable exit(EXIT_SUCCESS)

### DIFF
--- a/libselinux/utils/avcstat.c
+++ b/libselinux/utils/avcstat.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 		case 'h':
 		case '-':
 			usage();
-			exit(0);
+			exit(EXIT_SUCCESS);
 		default:
 			usage();
 			die("unrecognized parameter '%c'", i);
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 		}
 		if (n == 0) {
 			usage();
-			exit(0);
+			exit(EXIT_SUCCESS);
 		}
 		interval = n;
 	}

--- a/libselinux/utils/compute_av.c
+++ b/libselinux/utils/compute_av.c
@@ -51,5 +51,5 @@ int main(int argc, char **argv)
 		printf("\n");
 	}
 
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/compute_create.c
+++ b/libselinux/utils/compute_create.c
@@ -32,5 +32,5 @@ int main(int argc, char **argv)
 
 	printf("%s\n", buf);
 	freecon(buf);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/compute_member.c
+++ b/libselinux/utils/compute_member.c
@@ -32,5 +32,5 @@ int main(int argc, char **argv)
 
 	printf("%s\n", buf);
 	freecon(buf);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/compute_relabel.c
+++ b/libselinux/utils/compute_relabel.c
@@ -32,5 +32,5 @@ int main(int argc, char **argv)
 
 	printf("%s\n", buf);
 	freecon(buf);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/compute_user.c
+++ b/libselinux/utils/compute_user.c
@@ -27,12 +27,12 @@ int main(int argc, char **argv)
 
 	if (!buf[0]) {
 		printf("none\n");
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	for (ptr = buf; *ptr; ptr++) {
 		printf("%s\n", *ptr);
 	}
 	freeconary(buf);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/getfilecon.c
+++ b/libselinux/utils/getfilecon.c
@@ -23,5 +23,5 @@ int main(int argc, char **argv)
 		printf("%s\t%s\n", argv[i], buf);
 		freecon(buf);
 	}
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/getpidcon.c
+++ b/libselinux/utils/getpidcon.c
@@ -27,5 +27,5 @@ int main(int argc, char **argv)
 
 	printf("%s\n", buf);
 	freecon(buf);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/getseuser.c
+++ b/libselinux/utils/getseuser.c
@@ -36,5 +36,5 @@ int main(int argc, char **argv)
 	for (i = 0; i < n; i++)
 		printf("Context %d\t%s\n", i, contextlist[i]);
 	freeconary(contextlist);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/policyvers.c
+++ b/libselinux/utils/policyvers.c
@@ -14,5 +14,5 @@ int main(int argc __attribute__ ((unused)), char **argv)
 	}
 
 	printf("%d\n", rc);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/libselinux/utils/setfilecon.c
+++ b/libselinux/utils/setfilecon.c
@@ -20,5 +20,5 @@ int main(int argc, char **argv)
 			exit(2);
 		}
 	}
-	exit(0);
+	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Another trivial patch to improve code readability. I did not replace exit(1) with EXIT_FAILURE, because some of the code uses exit(2), exit(3) etc, so preferred to keep the raw integers there.