### PR TITLE
libsepol/cil: fix mlsconstrain segfault

### DIFF
--- a/libsepol/cil/src/cil_verify.c
+++ b/libsepol/cil/src/cil_verify.c
@@ -225,6 +225,9 @@ int cil_verify_constraint_leaf_expr_syntax(enum cil_flavor l_flavor, enum cil_fl
 				cil_log(CIL_ERR, "u3, r3, and t3 can only be used with (mls)validatetrans rules\n");
 				goto exit;
 			}
+		} else if (r_flavor == CIL_LIST) {
+			cil_log(CIL_ERR, "t1, t2, r1, r2, u1, u2 cannot be used on the left side with a list on the right side\n");
+			goto exit;
 		}
 	} else {
 		if (r_flavor == CIL_CONS_U2) {


### PR DESCRIPTION
Installing a cil module with invalid mlsconstrain syntax currently
results in a segfault. In the following module, the right-hand side of
the second operand of the OR is a list (mlstrustedobject):

$ cat test.cil
(class test (foo) )
(classorder (unordered test))

(mlsconstrain (test (foo))
	(or
		(dom h1 h2)
		(eq t2 (mlstrustedobject))
	)
)

$ sudo semodule -i test.cil
zsh: segmentation fault  sudo semodule -i test.cil

This syntax is invalid and should error accordingly, rather than
segfaulting. This patch provides this syntax error for the same module:

$ sudo semodule -i test.cil
t1, t2, r1, r2, u1, u2 cannot be used on the left side with a list on the right side
Bad expression tree for constraint
Bad constrain declaration at /var/lib/selinux/mls/tmp/modules/400/test/cil:4
semodule:  Failed!

Signed-off-by: Mike Palmiotto <mike.palmiotto@crunchydata.com>