### PR TITLE
Use quote include for files located in the local directory

### DIFF
--- a/libsepol/src/private.h
+++ b/libsepol/src/private.h
@@ -2,8 +2,9 @@
 
 /* Endian conversion for reading and writing binary policies */
 
-#include <sepol/policydb/policydb.h>
+#include "dso.h"
 
+#include <sepol/policydb/policydb.h>
 
 #ifdef __APPLE__
 #include <sys/types.h>
@@ -14,7 +15,6 @@
 #endif
 
 #include <errno.h>
-#include <dso.h>
 
 #ifdef __APPLE__
 #define __BYTE_ORDER  BYTE_ORDER

--- a/libsepol/src/util.c
+++ b/libsepol/src/util.c
@@ -18,6 +18,8 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "dso.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <stdarg.h>
@@ -27,7 +29,6 @@
 #include <sepol/policydb/flask_types.h>
 #include <sepol/policydb/policydb.h>
 #include <sepol/policydb/util.h>
-#include <dso.h>
 
 struct val_to_name {
 	unsigned int val;


### PR DESCRIPTION
It fixes Android tool compilation error with the host toolchain:

  selinux/libsepol/src/util.c:30:10: error: 'dso.h' file not found with <angled> include; use "quotes" instead
  #include <dso.h>
         ^~~~~~~
         "dso.h"

Change-Id: I26b387cb1f1546003cf8fa156606008589ae5e40