### PR TITLE
Add configuration file for lgtm.com

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  cpp:
+    index:
+      build_command:
+        - make DESTDIR="$LGTM_WORKSPACE/destdir" install


### PR DESCRIPTION
Add a configuration file in order to parse the C code on
https://lgtm.com/projects/g/SELinuxProject/selinux/

The documentation about this file is on
https://help.semmle.com/lgtm-enterprise/user/help/lgtm.yml-configuration-file.html
and
https://help.semmle.com/lgtm-enterprise/user/help/cpp-extraction.html

Fixes: https://github.com/SELinuxProject/selinux/issues/98

Signed-off-by: Nicolas Iooss <nicolas.iooss@m4x.org>