### PR TITLE
policycoreutils: semodule: Enable CIL logging

### DIFF
--- a/policycoreutils/semodule/semodule.c
+++ b/policycoreutils/semodule/semodule.c
@@ -22,6 +22,7 @@
 #include <libgen.h>
 #include <limits.h>
 
+#include <sepol/cil/cil.h>
 #include <semanage/modules.h>
 
 enum client_modes {
@@ -238,7 +239,7 @@ static void parse_command_line(int argc, char **argv)
 			set_mode(LIST_M, optarg);
 			break;
 		case 'v':
-			verbose = 1;
+			verbose++;
 			break;
 		case 'r':
 			set_mode(REMOVE_M, optarg);
@@ -349,6 +350,8 @@ int main(int argc, char *argv[])
 		argv = (char **)genhomedirconargv;
 	}
 	parse_command_line(argc, argv);
+
+	cil_set_log_level(CIL_ERR + verbose);
 
 	if (build)
 		commit = 1;


### PR DESCRIPTION
semodule -v will turn on semodule's own verbose logging but not logging
from CIL. This change makes the verbose flag also set cil's log level.

By default (ie no -v flag), this will enable CIL_ERR, and each -v will
increase the level from there.

Tested with a duplicated fcontext in the policy.
Before this change:
    # semodule -v -B
    Committing changes:
    Problems processing filecon rules
    Failed post db handling
    semodule:  Failed!

After this change:
    # semodule -v -B
    [ ... snip ... ]
    Found conflicting filecon rules
      at /var/lib/selinux/mcs/tmp/modules/400/mycustom/cil:159
      at /var/lib/selinux/mcs/tmp/modules/400/mycustom/cil:158
    Problems processing filecon rules
    Failed post db handling
    semodule:  Failed!

Closes: https://github.com/SELinuxProject/selinux/issues/176
Signed-off-by: Jason Zaman <jason@perfinion.com>