### PR TITLE
src/Makefile: don't pass bogus -I and -L to python setup.py build_ext

### DIFF
--- a/libselinux/src/Makefile
+++ b/libselinux/src/Makefile
@@ -130,7 +130,7 @@ SWIGRUBY = swig -Wall -ruby -o $(SWIGRUBYCOUT) -outdir ./ $(DISABLE_FLAGS)
 all: $(LIBA) $(LIBSO) $(LIBPC)
 
 pywrap: all selinuxswig_python_exception.i
-	CFLAGS="$(CFLAGS) $(SWIG_CFLAGS)" $(PYTHON) setup.py build_ext -I $(DESTDIR)$(INCLUDEDIR) -L $(DESTDIR)$(LIBDIR)
+	CFLAGS="$(CFLAGS) $(SWIG_CFLAGS)" $(PYTHON) setup.py build_ext
 
 rubywrap: all $(SWIGRUBYSO)
 


### PR DESCRIPTION
Using $(DESTDIR) during the build does not follow the normal/standard
semantic of DESTDIR: it is normally only needed during the
installation. Therefore, a lot of build systems/environments don't
pass any DESTDIR at build time, which causes setup.py to be called
with -I /usr/include -L /usr/lib, which breaks cross-compilation.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>