### PR TITLE
Fix: check variable type of port before trying to split

### DIFF
--- a/python/semanage/seobject.py
+++ b/python/semanage/seobject.py
@@ -1070,7 +1070,11 @@ class portRecords(semanageRecords):
         if port == "":
             raise ValueError(_("Port is required"))
 
-        ports = port.split("-")
+        if isinstance(port, str):
+            ports = port.split('-', 1)
+        else:
+            ports = (port,)
+
         if len(ports) == 1:
             high = low = int(ports[0])
         else:


### PR DESCRIPTION
I have been trying to use Ansible for SE Linux Port management, and it crashes if I used numbered ports.
