### PR TITLE
checkpolicy: mark te_assert_t as extern to prevent build failures

### DIFF
--- a/checkpolicy/checkpolicy.h
+++ b/checkpolicy/checkpolicy.h
@@ -13,7 +13,7 @@ typedef struct te_assert {
 	struct te_assert *next;
 } te_assert_t;
 
-te_assert_t *te_assertions;
+extern te_assert_t *te_assertions;
 
 extern unsigned int policyvers;
 


### PR DESCRIPTION
due to multiple definitions in gcc10