### PR TITLE
cil: drop remaining dso.h include

### DIFF
--- a/libsepol/cil/src/cil.c
+++ b/libsepol/cil/src/cil.c
@@ -50,7 +50,6 @@
 #include "cil_binary.h"
 #include "cil_policy.h"
 #include "cil_strpool.h"
-#include "dso.h"
 
 #ifndef DISABLE_SYMVER
 asm(".symver cil_build_policydb_pdb,        cil_build_policydb@LIBSEPOL_1.0");


### PR DESCRIPTION
Acked-by: Ondrej Mosnacek <omosnace@redhat.com>
Signed-off-by: William Roberts <william.c.roberts@intel.com>