### PR TITLE
libselinux: mount selinuxfs nodev,noexec,nosuid

### DIFF
--- a/libselinux/src/load_policy.c
+++ b/libselinux/src/load_policy.c
@@ -279,7 +279,7 @@ int selinux_init_load_policy(int *enforce)
 	const char *mntpoint = NULL;
 	/* First make sure /sys is mounted */
 	if (mount("sysfs", "/sys", "sysfs", 0, 0) == 0 || errno == EBUSY) {
-		if (mount(SELINUXFS, SELINUXMNT, SELINUXFS, 0, 0) == 0 || errno == EBUSY) {
+		if (mount(SELINUXFS, SELINUXMNT, SELINUXFS, MS_NODEV | MS_NOEXEC | MS_NOSUID, 0) == 0 || errno == EBUSY) {
 			mntpoint = SELINUXMNT;
 		} else {
 			/* check old mountpoint */


### PR DESCRIPTION
Mount selinuxfs with mount flags nodev,noexec and nosuid. It's not
likely that this has any effect, but it's visually more pleasing.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>