### PR TITLE
Fix building against musl and uClibc libc libraries.

### DIFF
--- a/libselinux/utils/Makefile
+++ b/libselinux/utils/Makefile
@@ -45,7 +45,7 @@ endif
 
 override CFLAGS += -I../include -D_GNU_SOURCE $(DISABLE_FLAGS) $(PCRE_CFLAGS)
 override LDFLAGS += -L../src
-override LDLIBS += -lselinux
+override LDLIBS += -lselinux $(FTS_LDLIBS)
 PCRE_LDLIBS ?= -lpcre
 
 ifeq ($(ANDROID_HOST),y)


### PR DESCRIPTION
Currently, the src/Makefile provides the FTS_LDLIBS when building against musl
or uClibc. However, this is missing from utils/Makefile, which causes linking
to fail.

Add the FTS_LDLIBS variable to the LDLIBS variable in utils/Makefile to fix
compiling against uClibc and musl.

Signed-off-by: Adam Duskett <Aduskett@gmail.com>