### PR TITLE
setsebool: report errors from commit phase

### DIFF
--- a/policycoreutils/setsebool/setsebool.c
+++ b/policycoreutils/setsebool/setsebool.c
@@ -200,8 +200,10 @@ static int semanage_set_boolean_list(size_t boolcnt,
 
 	if (no_reload)
 		semanage_set_reload(handle, 0);
-	if (semanage_commit(handle) < 0)
+	if (semanage_commit(handle) < 0) {
+		fprintf(stderr, "Failed to commit changes to booleans: %m\n");
 		goto err;
+	}
 
 	semanage_disconnect(handle);
 	semanage_handle_destroy(handle);


### PR DESCRIPTION
In case there are errors when committing changes to booleans, the
errors may not be reported to user except by nonzero exit status. With
"setsebool -V" it's possible to see errors from commit phase, but
otherwise the unfixed command is silent:

 # setsebool -V -P secure_mode_insmod=off
libsemanage.semanage_install_final_tmp: Could not copy /var/lib/selinux/final/default/contexts/files/file_contexts to /etc/selinux/default/contexts/files/file_contexts. (Read-only file system).
libsemanage.semanage_install_final_tmp: Could not copy /var/lib/selinux/final/default/contexts/files/file_contexts to /etc/selinux/default/contexts/files/file_contexts. (Read-only file system).

Fixed version alerts the user about problems even without -V:
 # setsebool -P secure_mode_insmod=off
Failed to commit changes to booleans: Read-only file system

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>