### PR TITLE
sepolicy: fix some typos and port definitions

### DIFF
--- a/python/sepolicy/sepolicy/generate.py
+++ b/python/sepolicy/sepolicy/generate.py
@@ -340,7 +340,7 @@ class policy:
             (self.generate_root_user_types, self.generate_root_user_rules),
             (self.generate_new_types, self.generate_new_rules))
         if not re.match(r"^[a-zA-Z0-9-_]+$", name):
-            raise ValueError(_("Name must be alpha numeric with no spaces. Consider using option \"-n MODULENAME\""))
+            raise ValueError(_("Name must be alphanumeric with no spaces. Consider using option \"-n MODULENAME\""))
 
         if type == CGI:
             self.name = "httpd_%s_script" % name
@@ -438,7 +438,7 @@ class policy:
 
     def set_init_script(self, initscript):
         if self.type != DAEMON:
-            raise ValueError(_("Only Daemon apps can use an init script.."))
+            raise ValueError(_("Only Daemon apps can use an init script."))
 
         self.initscript = initscript
 

--- a/python/sepolicy/sepolicy/interface.py
+++ b/python/sepolicy/sepolicy/interface.py
@@ -198,7 +198,7 @@ def get_xml_file(if_file):
     filename = os.path.basename(if_file).split(".")[0]
     rc, output = getstatusoutput("/usr/bin/python3 /usr/share/selinux/devel/include/support/segenxml.py -w -m %s" % (basedir + filename))
     if rc != 0:
-        sys.stderr.write("\n Could not proceed selected interface file.\n")
+        sys.stderr.write("\n Could not process selected interface file.\n")
         sys.stderr.write("\n%s" % output)
         sys.exit(1)
     else:

--- a/python/sepolicy/sepolicy/network.py
+++ b/python/sepolicy/sepolicy/network.py
@@ -49,15 +49,15 @@ def get_network_connect(src, protocol, perm, check_bools=False):
                 if "port_t" in tlist:
                     continue
             if i == "port_t":
-                d[(src, protocol, perm)].append((i, ["all ports with out defined types"]))
+                d[(src, protocol, perm)].append((i, ["all ports without defined types"]))
             if i == "port_type":
                 d[(src, protocol, perm)].append((i, ["all ports"]))
             elif i == "unreserved_port_type":
-                d[(src, protocol, perm)].append((i, ["all ports > 1024"]))
+                d[(src, protocol, perm)].append((i, ["all ports >= 1024"]))
             elif i == "reserved_port_type":
                 d[(src, protocol, perm)].append((i, ["all ports < 1024"]))
             elif i == "rpc_port_type":
-                d[(src, protocol, perm)].append((i, ["all ports > 500 and  < 1024"]))
+                d[(src, protocol, perm)].append((i, ["all ports >= 512 and < 1024"]))
             else:
                 try:
                     d[(src, protocol, perm)].append((i, portrecs[(i, protocol)]))


### PR DESCRIPTION
The range of unreserved ports starts from 1024 and ends to
65535 (inclusive). (Secure) RPC ports can be between 512 and
1023 (inclusive).

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>