### PR TITLE
sepolicy-gui: fix columns in transitions view

### DIFF
--- a/python/sepolicy/sepolicy/sepolicy.glade
+++ b/python/sepolicy/sepolicy/sepolicy.glade
@@ -2877,19 +2877,9 @@ Enabled</property>
                                           </object>
                                         </child>
                                         <child>
-                                          <object class="GtkTreeViewColumn" id="treeviewcolumn27">
-                                            <child>
-                                              <object class="GtkCellRendererText" id="cellrenderertext34"/>
-                                              <attributes>
-                                                <attribute name="text">1</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
                                           <object class="GtkTreeViewColumn" id="executable_file_from">
                                             <property name="resizable">True</property>
-                                            <property name="title" translatable="yes">Boolean name</property>
+                                            <property name="title" translatable="yes">Executable File</property>
                                             <property name="expand">True</property>
                                             <property name="clickable">True</property>
                                             <property name="reorderable">True</property>


### PR DESCRIPTION
Delete an unused column from view "Application Transitions From". The
second column displays names of the executable files instead of
booleans.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>