### PR TITLE
libselinux: mark security_context_t typedef as deprecated

### DIFF
--- a/libselinux/include/selinux/selinux.h
+++ b/libselinux/include/selinux/selinux.h
@@ -14,7 +14,11 @@ extern int is_selinux_enabled(void);
 extern int is_selinux_mls_enabled(void);
 
 /* No longer used; here for compatibility with legacy callers. */
-typedef char *security_context_t;
+typedef char *security_context_t
+#ifdef __GNUC__
+__attribute__ ((deprecated))
+#endif
+;
 
 /* Free the memory allocated for a context by any of the below get* calls. */
 extern void freecon(char * con);


### PR DESCRIPTION
Follow-up of: 9eb9c9327563014ad6a807814e7975424642d5b9 ("Get rid of security_context_t and fix const declarations.")

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>