### PR TITLE
mcstransd: fix memory leak in new_context_str

### DIFF
--- a/mcstrans/src/mcstrans.c
+++ b/mcstrans/src/mcstrans.c
@@ -919,6 +919,7 @@ new_context_str(const char *incon, const char *range) {
 	}
 	context_range_set(con, range);
 	rcon = strdup(context_str(con));
+	context_free(con);
 	if (!rcon) {
 		goto exit;
 	}


### PR DESCRIPTION
The return value of context_new needs to be free with context_free.

Acked-by: William Roberts <william.c.roberts@intel.com>
Signed-off-by: bauen1 <j2468h@gmail.com>