### PR TITLE
secilc/docs: fix use of TMPDIR

### DIFF
--- a/secilc/docs/Makefile
+++ b/secilc/docs/Makefile
@@ -1,8 +1,8 @@
-CWD ?= $(shell pwd)
-HTMLDIR ?= $(CWD)/html
-PDFDIR ?= $(CWD)/pdf
-TMPDIR ?= $(CWD)/tmp
-TESTDIR ?= $(CWD)/../test
+CWD = $(shell pwd)
+HTMLDIR = $(CWD)/html
+PDFDIR = $(CWD)/pdf
+TMPDIR = $(CWD)/tmp
+TESTDIR = $(CWD)/../test
 
 # All the markdown files that make up the guide:
 FILE_LIST ?= cil_introduction.md \


### PR DESCRIPTION
Environment variable TMPDIR may be already set for the user building
and this could be equal to $XDG_RUNTIME_DIR or /tmp which are existing
directories. Then when running 'make clean', there are unintended side
effects:

rm -rf /run/user/1000
rm: cannot remove '/run/user/1000/dconf/user': Permission denied
rm: cannot remove '/run/user/1000/systemd': Permission denied
rm: cannot remove '/run/user/1000/gnupg': Permission denied
rm: cannot remove '/run/user/1000/dbus-1': Is a directory
rm: cannot remove '/run/user/1000/inaccessible': Permission denied
make[1]: *** [Makefile:68: clean] Error 1

Fix by using a different name.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>