### PR TITLE
Add restorecon -x to not cross FS boundaries

### DIFF
--- a/policycoreutils/setfiles/setfiles.c
+++ b/policycoreutils/setfiles/setfiles.c
@@ -43,8 +43,8 @@ static __attribute__((__noreturn__)) void usage(const char *const name)
 {
 	if (iamrestorecon) {
 		fprintf(stderr,
-			"usage:  %s [-iIDFmnprRv0] [-e excludedir] pathname...\n"
-			"usage:  %s [-iIDFmnprRv0] [-e excludedir] -f filename\n",
+			"usage:  %s [-iIDFmnprRv0x] [-e excludedir] pathname...\n"
+			"usage:  %s [-iIDFmnprRv0x] [-e excludedir] -f filename\n",
 			name, name);
 	} else {
 		fprintf(stderr,
@@ -385,6 +385,13 @@ int main(int argc, char **argv)
 			break;
 		case '0':
 			null_terminated = 1;
+			break;
+		case 'x':
+			if (iamrestorecon) {
+				r_opts.xdev = SELINUX_RESTORECON_XDEV;
+			} else {
+				usage(argv[0]);
+			}
 			break;
 		case 'h':
 		case '?':


### PR DESCRIPTION
As per #208, add the option -x to prevent restorecon from cross file system boundaries, by setting SELINUX_RESTORECON_XDEV iff iamrestorecon. If setfiles, call usage().