### PR TITLE
Add restorecon -x opt to not cross FS boundaries

### DIFF
--- a/policycoreutils/setfiles/restorecon.8
+++ b/policycoreutils/setfiles/restorecon.8
@@ -13,6 +13,7 @@ restorecon \- restore file(s) default SELinux security contexts.
 .RB [ \-F ]
 .RB [ \-W ]
 .RB [ \-I | \-D ]
+.RB [ \-x ]
 .RB [ \-e
 .IR directory ]
 .IR pathname \ ...
@@ -31,6 +32,7 @@ restorecon \- restore file(s) default SELinux security contexts.
 .RB [ \-F ]
 .RB [ \-W ]
 .RB [ \-I | \-D ]
+.RB [ \-x ]
 
 .SH "DESCRIPTION"
 This manual page describes the
@@ -152,6 +154,11 @@ quote marks or backslashes.  The
 option of GNU
 .B find
 produces input suitable for this mode.
+.TP
+.B \-x
+prevent
+.B restorecon
+from crossing file system boundaries.
 .TP
 .SH "ARGUMENTS"
 .IR pathname \ ...


### PR DESCRIPTION
As per SELinuxProject#208, add the option -x to prevent restorecon from cross file system boundaries.