### PR TITLE
fix NULL pointer use in selinux_restorecon_set_sehandle

### DIFF
--- a/libselinux/src/selinux_restorecon.c
+++ b/libselinux/src/selinux_restorecon.c
@@ -1153,9 +1153,11 @@ void selinux_restorecon_set_sehandle(struct selabel_handle *hndl)
 	size_t num_specfiles, fc_digest_len;
 
 	fc_sehandle = (struct selabel_handle *) hndl;
+	if (!fc_sehandle)
+		return;
 
 	/* Check if digest requested in selabel_open(3), if so use it. */
-	if (fc_sehandle == NULL || selabel_digest(fc_sehandle, &fc_digest, &fc_digest_len,
+	if (selabel_digest(fc_sehandle, &fc_digest, &fc_digest_len,
 				   &specfiles, &num_specfiles) < 0)
 		selabel_no_digest = true;
 	else

--- a/libselinux/src/selinux_restorecon.c
+++ b/libselinux/src/selinux_restorecon.c
@@ -1155,7 +1155,7 @@ void selinux_restorecon_set_sehandle(struct selabel_handle *hndl)
 	fc_sehandle = (struct selabel_handle *) hndl;
 
 	/* Check if digest requested in selabel_open(3), if so use it. */
-	if (selabel_digest(fc_sehandle, &fc_digest, &fc_digest_len,
+	if (fc_sehandle == NULL || selabel_digest(fc_sehandle, &fc_digest, &fc_digest_len,
 				   &specfiles, &num_specfiles) < 0)
 		selabel_no_digest = true;
 	else


### PR DESCRIPTION
error occur when selinux_restorecon_default_handle return NULL in restorecon_init