### PR TITLE
Add #include <limits.h> from sepolgen-ifgen-attr-helper.c

### DIFF
--- a/python/audit2allow/sepolgen-ifgen-attr-helper.c
+++ b/python/audit2allow/sepolgen-ifgen-attr-helper.c
@@ -28,6 +28,7 @@
 
 #include <selinux/selinux.h>
 
+#include <limits.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
I found that building on OpenWrt/musl failed with:

	sepolgen-ifgen-attr-helper.c:152:16: error: 'PATH_MAX' undeclared ...

Musl is less "generous" than glibc in recursively including header files,
and I suspect this is the reason for this error. Explicitly including
limits.h fixes the problem.

Signed-off-by: W. Michael Petullo <mike@flyn.org>