### PR TITLE
restorecond: Set X-GNOME-HiddenUnderSystemd=true in restorecond.deskt…

### DIFF
--- a/restorecond/restorecond.desktop
+++ b/restorecond/restorecond.desktop
@@ -5,3 +5,4 @@ Comment=Fix file context in owned by the user
 Type=Application
 StartupNotify=false
 X-GNOME-Autostart-enabled=false
+X-GNOME-HiddenUnderSystemd=true


### PR DESCRIPTION
…op file

This completely inactivate the .desktop file incase the user session is
managed by systemd as restorecond also provide a service file