### PR TITLE
ci: fix stall on git log -1

### DIFF
--- a/scripts/ci/fedora-test-runner.sh
+++ b/scripts/ci/fedora-test-runner.sh
@@ -67,7 +67,7 @@ dnf install -y \
 cd "$SELINUX_DIR"
 
 # Show HEAD commit for sanity checking
-git log -1
+git log --oneline -1
 
 #
 # Build and replace userspace components


### PR DESCRIPTION
git log -1 may use a pager to output long messages, and when the pager
is invoked, leads to stalls on the ci system waiting for user input.
Use --oneline to print the short part of the commit message and
the digest. This information is for debug/informational purposes only,
so truncating the output is sufficient.

Reported-by: Stephen Smalley <sds@tycho.nsa.gov>
Signed-off-by: William Roberts <william.c.roberts@intel.com>