### PR TITLE
libsemanage: Free contents of modkey in semanage_direct_remove

### DIFF
--- a/libsemanage/src/direct_api.c
+++ b/libsemanage/src/direct_api.c
@@ -1951,6 +1951,7 @@ static int semanage_direct_remove(semanage_handle_t * sh, char *module_name)
 	status = semanage_direct_remove_key(sh, &modkey);
 
 cleanup:
+	semanage_module_key_destroy(sh, &modkey);
 	return status;
 }
 


### PR DESCRIPTION
semanage_direct_remove allocates struct semanage_module_key_t on
stack, then calls semanage_module_key_set_name which allocates
modkey->name on heap, but modkey->name wasn't free()-d anywhere,
creating a small leak.