### PR TITLE
ci: turn on CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,39 @@
+---
+name: CIFuzz
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    if: github.repository == 'SELinuxProject/selinux'
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined, memory]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'selinux'
+          dry-run: false
+          allowed-broken-targets-percentage: 0
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: 'selinux'
+          fuzz-seconds: 180
+          dry-run: false
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Upload Crash
+        uses: actions/upload-artifact@v1
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: ${{ matrix.sanitizer }}-artifacts
+          path: ./out/artifacts

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ SELinux Userspace
 
 ![SELinux logo](https://github.com/SELinuxProject.png)
 [![Build Status](https://travis-ci.org/SELinuxProject/selinux.svg?branch=master)](https://travis-ci.org/SELinuxProject/selinux)
+[![OSS-Fuzz Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/selinux.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#selinux)
+[![CIFuzz Status](https://github.com/SELinuxProject/selinux/actions/workflows/cifuzz.yml/badge.svg)](https://github.com/SELinuxProject/selinux/actions/workflows/cifuzz.yml)
 
 Please submit all bug reports and patches to <selinux@vger.kernel.org>.
 


### PR DESCRIPTION
Now that roughly half the bugs reported by OSS-Fuzz have been
fixed libsepol/cil should be stable enough to get CIFuzz working
more or less reliably. It should help to catch regressions/new bugs
faster.

https://google.github.io/oss-fuzz/getting-started/continuous-integration/

@fishilico could you take a look?