### PR TITLE
RFC: replace strerror by %m

### DIFF
--- a/libselinux/src/audit2why.c
+++ b/libselinux/src/audit2why.c
@@ -204,8 +204,8 @@ static int __policy_init(const char *init_path)
 		fp = fopen(path, "re");
 		if (!fp) {
 			snprintf(errormsg, sizeof(errormsg), 
-				 "unable to open %s:  %s\n",
-				 path, strerror(errno));
+				 "unable to open %s:  %m\n",
+				 path);
 			PyErr_SetString( PyExc_ValueError, errormsg);
 			return 1;
 		}
@@ -221,9 +221,8 @@ static int __policy_init(const char *init_path)
 		fp = fopen(curpolicy, "re");
 		if (!fp) {
 			snprintf(errormsg, sizeof(errormsg), 
-				 "unable to open %s:  %s\n",
-				 curpolicy,
-				 strerror(errno));
+				 "unable to open %s:  %m\n",
+				 curpolicy);
 			PyErr_SetString( PyExc_ValueError, errormsg);
 			return 1;
 		}
@@ -242,7 +241,7 @@ static int __policy_init(const char *init_path)
 	if (sepol_policy_file_create(&pf) ||
 	    sepol_policydb_create(&avc->policydb)) {
 		snprintf(errormsg, sizeof(errormsg), 
-			 "policydb_init failed: %s\n", strerror(errno));
+			 "policydb_init failed: %m\n");
 		PyErr_SetString( PyExc_RuntimeError, errormsg);
 		fclose(fp);
 		return 1;

--- a/libselinux/src/avc.c
+++ b/libselinux/src/avc.c
@@ -206,9 +206,8 @@ static int avc_init_internal(const char *prefix,
 		rc = security_getenforce();
 		if (rc < 0) {
 			avc_log(SELINUX_ERROR,
-				"%s:  could not determine enforcing mode: %s\n",
-				avc_prefix,
-				strerror(errno));
+				"%s:  could not determine enforcing mode: %m\n",
+				avc_prefix);
 			goto out;
 		}
 		avc_enforcing = rc;
@@ -217,8 +216,8 @@ static int avc_init_internal(const char *prefix,
 	rc = selinux_status_open(0);
 	if (rc < 0) {
 		avc_log(SELINUX_ERROR,
-			"%s: could not open selinux status page: %d (%s)\n",
-			avc_prefix, errno, strerror(errno));
+			"%s: could not open selinux status page: %d (%m)\n",
+			avc_prefix, errno);
 		goto out;
 	}
 	avc_running = 1;

--- a/libselinux/src/avc_internal.c
+++ b/libselinux/src/avc_internal.c
@@ -308,8 +308,8 @@ int avc_netlink_acquire_fd(void)
 		rc = avc_netlink_open(0);
 		if (rc < 0) {
 			avc_log(SELINUX_ERROR,
-				"%s: could not open netlink socket: %d (%s)\n",
-				avc_prefix, errno, strerror(errno));
+				"%s: could not open netlink socket: %d (%m)\n",
+				avc_prefix, errno);
 			return rc;
 		}
 	}

--- a/libselinux/src/label_backends_android.c
+++ b/libselinux/src/label_backends_android.c
@@ -94,9 +94,15 @@ static int process_line(struct selabel_handle *rec,
 	items = read_spec_entries(line_buf, &errbuf, 2, &prop, &context);
 	if (items < 0) {
 		items = errno;
-		selinux_log(SELINUX_ERROR,
-			"%s:  line %u error due to: %s\n", path,
-			lineno, errbuf ?: strerror(errno));
+		if (errbuf) {
+			selinux_log(SELINUX_ERROR,
+				    "%s:  line %u error due to: %s\n", path,
+				    lineno, errbuf);
+		} else {
+			selinux_log(SELINUX_ERROR,
+				    "%s:  line %u error due to: %m\n", path,
+				    lineno);
+		}
 		errno = items;
 		return -1;
 	}

--- a/libselinux/src/label_file.h
+++ b/libselinux/src/label_file.h
@@ -445,9 +445,15 @@ static inline int process_line(struct selabel_handle *rec,
 	items = read_spec_entries(line_buf, &errbuf, 3, &regex, &type, &context);
 	if (items < 0) {
 		rc = errno;
-		selinux_log(SELINUX_ERROR,
-			"%s:  line %u error due to: %s\n", path,
-			lineno, errbuf ?: strerror(errno));
+		if (errbuf) {
+			selinux_log(SELINUX_ERROR,
+				    "%s:  line %u error due to: %s\n", path,
+				    lineno, errbuf);
+		} else {
+			selinux_log(SELINUX_ERROR,
+				    "%s:  line %u error due to: %m\n", path,
+				    lineno);
+		}
 		errno = rc;
 		return -1;
 	}

--- a/libselinux/src/load_policy.c
+++ b/libselinux/src/load_policy.c
@@ -137,15 +137,15 @@ int selinux_mkload_policy(int preservebools __attribute__((unused)))
 	}
 	if (fd < 0) {
 		fprintf(stderr,
-			"SELinux:  Could not open policy file <= %s.%d:  %s\n",
-			selinux_binary_policy_path(), maxvers, strerror(errno));
+			"SELinux:  Could not open policy file <= %s.%d:  %m\n",
+			selinux_binary_policy_path(), maxvers);
 		goto dlclose;
 	}
 
 	if (fstat(fd, &sb) < 0) {
 		fprintf(stderr,
-			"SELinux:  Could not stat policy file %s:  %s\n",
-			path, strerror(errno));
+			"SELinux:  Could not stat policy file %s:  %m\n",
+			path);
 		goto close;
 	}
 
@@ -153,8 +153,8 @@ int selinux_mkload_policy(int preservebools __attribute__((unused)))
 	data = map = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
 	if (map == MAP_FAILED) {
 		fprintf(stderr,
-			"SELinux:  Could not map policy file %s:  %s\n",
-			path, strerror(errno));
+			"SELinux:  Could not map policy file %s:  %m\n",
+			path);
 		goto close;
 	}
 
@@ -193,8 +193,8 @@ int selinux_mkload_policy(int preservebools __attribute__((unused)))
 	
 	if (rc)
 		fprintf(stderr,
-			"SELinux:  Could not load policy file %s:  %s\n",
-			path, strerror(errno));
+			"SELinux:  Could not load policy file %s:  %m\n",
+			path);
 
       unmap:
 	if (data != map)
@@ -306,7 +306,7 @@ int selinux_init_load_policy(int *enforce)
 			*enforce = 0;
 		} else {
 			/* Only emit this error if selinux was not disabled */
-			fprintf(stderr, "Mount failed for selinuxfs on %s:  %s\n", SELINUXMNT, strerror(errno));
+			fprintf(stderr, "Mount failed for selinuxfs on %s:  %m\n", SELINUXMNT);
 		}
 
 		if (rc == 0)
@@ -352,7 +352,7 @@ int selinux_init_load_policy(int *enforce)
 	if (orig_enforce != *enforce) {
 		rc = security_setenforce(*enforce);
 		if (rc < 0) {
-			fprintf(stderr, "SELinux:  Unable to switch to %s mode:  %s\n", (*enforce ? "enforcing" : "permissive"), strerror(errno));
+			fprintf(stderr, "SELinux:  Unable to switch to %s mode:  %m\n", (*enforce ? "enforcing" : "permissive"));
 			if (*enforce)
 				goto noload;
 		}

--- a/libselinux/src/matchpathcon.c
+++ b/libselinux/src/matchpathcon.c
@@ -393,8 +393,8 @@ int realpath_not_final(const char *name, char *resolved_path)
 
 	tmp_path = strdup(name);
 	if (!tmp_path) {
-		myprintf("symlink_realpath(%s) strdup() failed: %s\n",
-			name, strerror(errno));
+		myprintf("symlink_realpath(%s) strdup() failed: %m\n",
+			name);
 		rc = -1;
 		goto out;
 	}
@@ -414,8 +414,8 @@ int realpath_not_final(const char *name, char *resolved_path)
 	}
 
 	if (!p) {
-		myprintf("symlink_realpath(%s) realpath() failed: %s\n",
-			name, strerror(errno));
+		myprintf("symlink_realpath(%s) realpath() failed: %m\n",
+			name);
 		rc = -1;
 		goto out;
 	}

--- a/libsepol/src/ibpkey_record.c
+++ b/libsepol/src/ibpkey_record.c
@@ -38,8 +38,8 @@ static int ibpkey_parse_subnet_prefix(sepol_handle_t *handle,
 	struct in6_addr in_addr;
 
 	if (inet_pton(AF_INET6, subnet_prefix_str, &in_addr) <= 0) {
-		ERR(handle, "could not parse IPv6 address for ibpkey subnet prefix %s: %s",
-		    subnet_prefix_str, strerror(errno));
+		ERR(handle, "could not parse IPv6 address for ibpkey subnet prefix %s: %m",
+		    subnet_prefix_str);
 		return STATUS_ERR;
 	}
 
@@ -64,8 +64,7 @@ static int ibpkey_expand_subnet_prefix(sepol_handle_t *handle,
 	if (inet_ntop(AF_INET6, &addr, subnet_prefix_str,
 		      INET6_ADDRSTRLEN) == NULL) {
 		ERR(handle,
-		    "could not expand IPv6 address to string: %s",
-		    strerror(errno));
+		    "could not expand IPv6 address to string: %m");
 		return STATUS_ERR;
 	}
 

--- a/libsepol/src/kernel_to_cil.c
+++ b/libsepol/src/kernel_to_cil.c
@@ -2779,13 +2779,13 @@ static int write_selinux_node_rules_to_cil(FILE *out, struct policydb *pdb)
 
 	for (node = pdb->ocontexts[4]; node != NULL; node = node->next) {
 		if (inet_ntop(AF_INET, &node->u.node.addr, addr, INET_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon address is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET, &node->u.node.mask, mask, INET_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon mask is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2819,13 +2819,13 @@ static int write_selinux_node6_rules_to_cil(FILE *out, struct policydb *pdb)
 
 	for (node = pdb->ocontexts[6]; node != NULL; node = node->next) {
 		if (inet_ntop(AF_INET6, &node->u.node6.addr, addr, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon address is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET6, &node->u.node6.mask, mask, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon mask is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2867,8 +2867,7 @@ static int write_selinux_ibpkey_rules_to_cil(FILE *out, struct policydb *pdb)
 
 		if (inet_ntop(AF_INET6, &subnet_prefix.s6_addr,
 			      subnet_prefix_str, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("ibpkeycon subnet_prefix is invalid: %s",
-				      strerror(errno));
+			sepol_log_err("ibpkeycon subnet_prefix is invalid: %m");
 			rc = -1;
 			goto exit;
 		}

--- a/libsepol/src/kernel_to_conf.c
+++ b/libsepol/src/kernel_to_conf.c
@@ -2652,13 +2652,13 @@ static int write_selinux_node_rules_to_conf(FILE *out, struct policydb *pdb)
 
 	for (node = pdb->ocontexts[4]; node != NULL; node = node->next) {
 		if (inet_ntop(AF_INET, &node->u.node.addr, addr, INET_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon address is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET, &node->u.node.mask, mask, INET_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon mask is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2693,13 +2693,13 @@ static int write_selinux_node6_rules_to_conf(FILE *out, struct policydb *pdb)
 
 	for (node6 = pdb->ocontexts[6]; node6 != NULL; node6 = node6->next) {
 		if (inet_ntop(AF_INET6, &node6->u.node6.addr, addr, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon address is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET6, &node6->u.node6.mask, mask, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("Nodecon mask is invalid: %s", strerror(errno));
+			sepol_log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2741,8 +2741,7 @@ static int write_selinux_ibpkey_rules_to_conf(FILE *out, struct policydb *pdb)
 
 		if (inet_ntop(AF_INET6, &subnet_prefix.s6_addr,
 			      subnet_prefix_str, INET6_ADDRSTRLEN) == NULL) {
-			sepol_log_err("ibpkeycon address is invalid: %s",
-				      strerror(errno));
+			sepol_log_err("ibpkeycon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}

--- a/libsepol/src/module.c
+++ b/libsepol/src/module.c
@@ -796,7 +796,9 @@ int sepol_module_package_info(struct sepol_policy_file *spf, int *type,
 
 			len = le32_to_cpu(buf[0]);
 			if (str_read(name, file, len)) {
-				ERR(file->handle, "%s", strerror(errno));
+				ERR(file->handle,
+				    "cannot read module name (at section %u): %m",
+				    i);
 				goto cleanup;
 			}
 
@@ -809,7 +811,9 @@ int sepol_module_package_info(struct sepol_policy_file *spf, int *type,
 			}
 			len = le32_to_cpu(buf[0]);
 			if (str_read(version, file, len)) {
-				ERR(file->handle, "%s", strerror(errno));
+				ERR(file->handle,
+				    "cannot read module version (at section %u): %m",
+				i);
 				goto cleanup;
 			}
 			seen |= SEEN_MOD;

--- a/libsepol/src/module_to_cil.c
+++ b/libsepol/src/module_to_cil.c
@@ -2668,8 +2668,7 @@ static int ocontext_selinux_ibpkey_to_cil(struct policydb *pdb,
 
 		if (inet_ntop(AF_INET6, &subnet_prefix.s6_addr,
 			      subnet_prefix_str, INET6_ADDRSTRLEN) == NULL) {
-			log_err("ibpkeycon subnet_prefix is invalid: %s",
-				strerror(errno));
+			log_err("ibpkeycon subnet_prefix is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2714,13 +2713,13 @@ static int ocontext_selinux_node_to_cil(struct policydb *pdb, struct ocontext *n
 
 	for (node = nodes; node != NULL; node = node->next) {
 		if (inet_ntop(AF_INET, &node->u.node.addr, addr, INET_ADDRSTRLEN) == NULL) {
-			log_err("Nodecon address is invalid: %s", strerror(errno));
+			log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET, &node->u.node.mask, mask, INET_ADDRSTRLEN) == NULL) {
-			log_err("Nodecon mask is invalid: %s", strerror(errno));
+			log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
@@ -2746,13 +2745,13 @@ static int ocontext_selinux_node6_to_cil(struct policydb *pdb, struct ocontext *
 
 	for (node = nodes; node != NULL; node = node->next) {
 		if (inet_ntop(AF_INET6, &node->u.node6.addr, addr, INET6_ADDRSTRLEN) == NULL) {
-			log_err("Nodecon address is invalid: %s", strerror(errno));
+			log_err("Nodecon address is invalid: %m");
 			rc = -1;
 			goto exit;
 		}
 
 		if (inet_ntop(AF_INET6, &node->u.node6.mask, mask, INET6_ADDRSTRLEN) == NULL) {
-			log_err("Nodecon mask is invalid: %s", strerror(errno));
+			log_err("Nodecon mask is invalid: %m");
 			rc = -1;
 			goto exit;
 		}

--- a/libsepol/src/node_record.c
+++ b/libsepol/src/node_record.c
@@ -53,7 +53,7 @@ static int node_parse_addr(sepol_handle_t * handle,
 
 			if (inet_pton(AF_INET, addr_str, &in_addr) <= 0) {
 				ERR(handle, "could not parse IPv4 address "
-				    "%s: %s", addr_str, strerror(errno));
+				    "%s: %m", addr_str);
 				return STATUS_ERR;
 			}
 
@@ -66,7 +66,7 @@ static int node_parse_addr(sepol_handle_t * handle,
 
 			if (inet_pton(AF_INET6, addr_str, &in_addr) <= 0) {
 				ERR(handle, "could not parse IPv6 address "
-				    "%s: %s", addr_str, strerror(errno));
+				    "%s: %m", addr_str);
 				return STATUS_ERR;
 			}
 
@@ -147,8 +147,7 @@ static int node_expand_addr(sepol_handle_t * handle,
 				      INET_ADDRSTRLEN) == NULL) {
 
 				ERR(handle,
-				    "could not expand IPv4 address to string: %s",
-				    strerror(errno));
+				    "could not expand IPv4 address to string: %m");
 				return STATUS_ERR;
 			}
 			break;
@@ -163,8 +162,7 @@ static int node_expand_addr(sepol_handle_t * handle,
 				      INET6_ADDRSTRLEN) == NULL) {
 
 				ERR(handle,
-				    "could not expand IPv6 address to string: %s",
-				    strerror(errno));
+				    "could not expand IPv6 address to string: %m");
 				return STATUS_ERR;
 			}
 			break;

--- a/libsepol/src/services.c
+++ b/libsepol/src/services.c
@@ -145,7 +145,7 @@ int sepol_set_policydb_from_file(FILE * fp)
 	}
 	if (policydb_read(&mypolicydb, &pf, 0)) {
 		policydb_destroy(&mypolicydb);
-		ERR(NULL, "can't read binary policy: %s", strerror(errno));
+		ERR(NULL, "can't read binary policy: %m");
 		return -1;
 	}
 	policydb = &mypolicydb;


### PR DESCRIPTION
The standard function `strerror(3)` is not thread safe.  This does not
only affect the concurrent usage of libselinux itself but also with
other `strerror(3)` linked libraries.
Use the thread safe GNU extension format specifier `%m`[1].

libselinux already uses the GNU extension format specifier `%ms`.

[1]: https://www.gnu.org/software/libc/manual/html_node/Other-Output-Conversions.html