### PR TITLE
libselinux: use dummy variable to silence glibc 2.34 warnings

### DIFF
--- a/libselinux/src/matchpathcon.c
+++ b/libselinux/src/matchpathcon.c
@@ -356,7 +356,7 @@ int matchpathcon_init_prefix(const char *path, const char *subset)
 		mycanoncon = default_canoncon;
 
 	__selinux_once(once, matchpathcon_init_once);
-	__selinux_setspecific(destructor_key, (void *)1);
+	__selinux_setspecific(destructor_key, /* some valid address to please GCC */ &selinux_page_size);
 
 	options[SELABEL_OPT_SUBSET].type = SELABEL_OPT_SUBSET;
 	options[SELABEL_OPT_SUBSET].value = subset;

--- a/libselinux/src/procattr.c
+++ b/libselinux/src/procattr.c
@@ -68,7 +68,7 @@ void  __attribute__((destructor)) procattr_destructor(void)
 static inline void init_thread_destructor(void)
 {
 	if (destructor_initialized == 0) {
-		__selinux_setspecific(destructor_key, (void *)1);
+		__selinux_setspecific(destructor_key, /* some valid address to please GCC */ &selinux_page_size);
 		destructor_initialized = 1;
 	}
 }

--- a/libselinux/src/setrans_client.c
+++ b/libselinux/src/setrans_client.c
@@ -272,7 +272,7 @@ static inline void init_thread_destructor(void)
 	if (!has_setrans)
 		return;
 	if (destructor_initialized == 0) {
-		__selinux_setspecific(destructor_key, (void *)1);
+		__selinux_setspecific(destructor_key, /* some valid address to please GCC */ &selinux_page_size);
 		destructor_initialized = 1;
 	}
 }


### PR DESCRIPTION
Glibc 2.34 added an access function attribute to pthread_setspecific(3).
This leads to the following GCC warnings:

    In file included from matchpathcon.c:5:
    matchpathcon.c: In function ‘matchpathcon_init_prefix’:
    selinux_internal.h:38:25: error: ‘pthread_setspecific’ expecting 1 byte in a region of size 0 [-Werror=stringop-overread]
       38 |                         pthread_setspecific(KEY, VALUE);        \
          |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    matchpathcon.c:359:9: note: in expansion of macro ‘__selinux_setspecific’
      359 |         __selinux_setspecific(destructor_key, (void *)1);
          |         ^~~~~~~~~~~~~~~~~~~~~
    In file included from selinux_internal.h:2,
                     from matchpathcon.c:5:
    /usr/include/pthread.h:1167:12: note: in a call to function ‘pthread_setspecific’ declared with attribute ‘access (none, 2)’
     1167 | extern int pthread_setspecific (pthread_key_t __key,
          |            ^~~~~~~~~~~~~~~~~~~

The actual value and the validity of the passed pointer is irrelevant,
since it does not gets accessed internally by glibc and
pthread_getspecific(3) is not used.
Use a pointer to a (temporary) valid object to please GCC.

Closes: https://github.com/SELinuxProject/selinux/issues/311
Signed-off-by: Christian Göttsche <cgzones@googlemail.com>