### PR TITLE
libsepol/cil: support IPv4/IPv6 address embedding

### DIFF
--- a/libsepol/cil/src/cil_build_ast.c
+++ b/libsepol/cil/src/cil_build_ast.c
@@ -5668,10 +5668,10 @@ int cil_fill_ipaddr(struct cil_tree_node *addr_node, struct cil_ipaddr *addr)
 		goto exit;
 	}
 
-	if (strchr(addr_node->data, '.') != NULL) {
-		addr->family = AF_INET;
-	} else {
+	if (strchr(addr_node->data, ':') != NULL) {
 		addr->family = AF_INET6;
+	} else {
+		addr->family = AF_INET;
 	}
 
 	rc = inet_pton(addr->family, addr_node->data, &addr->ip);
@@ -5683,7 +5683,7 @@ int cil_fill_ipaddr(struct cil_tree_node *addr_node, struct cil_ipaddr *addr)
 	return SEPOL_OK;
 
 exit:
-	cil_log(CIL_ERR, "Bad ip address or netmask\n"); 
+	cil_log(CIL_ERR, "Bad ip address or netmask: %s\n", (addr_node && addr_node->data) ? (const char *)addr_node->data : "n/a");
 	return rc;
 }
 


### PR DESCRIPTION
Accept IPv6 addresses, like `::ffff:127.0.0.1`.
This allows using those in nodecon statements leading to fine grained
access control:

    type=AVC msg=audit(11/29/21 20:27:44.437:419) : avc:  granted  { node_bind } for  pid=27500 comm=intercept saddr=::ffff:127.0.0.1 src=46293 scontext=xuser_u:xuser_r:xuser_t:s0 tcontext=system_u:object_r:lo_node_t:s0 tclass=tcp_socket

Also print on conversion failures the address in question.

Signed-off-by: Christian Göttsche <cgzones@googlemail.com>