### PR TITLE
libselinux: make threadsafe for discover_class_cache

### DIFF
--- a/libselinux/src/stringrep.c
+++ b/libselinux/src/stringrep.c
@@ -19,6 +19,8 @@
 
 #define MAXVECTORS 8*sizeof(access_vector_t)
 
+pthread_mutex_t cache_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 struct discover_class_node {
 	char *name;
 	security_class_t value;
@@ -31,19 +33,23 @@ static struct discover_class_node *discover_class_cache = NULL;
 
 static struct discover_class_node * get_class_cache_entry_name(const char *s)
 {
+	__pthread_mutex_lock(&cache_mutex);
 	struct discover_class_node *node = discover_class_cache;
 
 	for (; node != NULL && strcmp(s,node->name) != 0; node = node->next);
 
+	__pthread_mutex_unlock(&cache_mutex);
 	return node;
 }
 
 static struct discover_class_node * get_class_cache_entry_value(security_class_t c)
 {
+	__pthread_mutex_lock(&cache_mutex);
 	struct discover_class_node *node = discover_class_cache;
 
 	for (; node != NULL && c != node->value; node = node->next);
 
+	__pthread_mutex_unlock(&cache_mutex);
 	return node;
 }
 
@@ -140,9 +146,10 @@ static struct discover_class_node * discover_class(const char *s)
 	}
 	closedir(dir);
 
+	__pthread_mutex_lock(&cache_mutex);
 	node->next = discover_class_cache;
 	discover_class_cache = node;
-
+	__pthread_mutex_unlock(&cache_mutex);
 	return node;
 
 err4:
@@ -160,6 +167,7 @@ err1:
 
 void selinux_flush_class_cache(void)
 {
+	__pthread_mutex_lock(&cache_mutex);
 	struct discover_class_node *cur = discover_class_cache, *prev = NULL;
 	size_t i;
 
@@ -178,6 +186,7 @@ void selinux_flush_class_cache(void)
 	}
 
 	discover_class_cache = NULL;
+	__pthread_mutex_unlock(&cache_mutex);
 }
 
 


### PR DESCRIPTION
Crash is observed in process dbus-daemon while accessing name
from discover_class_cache structure variable,
discover_class_cache->name variable found NULL
during backtrace analysis.
Add mutex lock for the discover_class_cache to handle multiple
threads for the function which uses discover_class_cache
This avoids variable corruption during parallel access
in the multiple thread environment.