### PR TITLE
Adjust sepolgen grammar to support allowxperm, et. al.

### DIFF
--- a/python/sepolgen/src/sepolgen/refparser.py
+++ b/python/sepolgen/src/sepolgen/refparser.py
@@ -349,6 +349,7 @@ def p_statement(p):
     '''statement : interface
                  | template
                  | obj_perm_set
+                 | obj_xperm_set
                  | policy
                  | policy_module_stmt
                  | module_stmt
@@ -502,7 +503,15 @@ def p_obj_perm_set(p):
     s = refpolicy.ObjPermSet(p[4])
     s.perms = p[8]
     p[0] = s
-    
+
+def p_obj_xperm_set(p):
+    'obj_xperm_set : DEFINE OPAREN TICK IDENTIFIER SQUOTE COMMA TICK xperm_set_base SQUOTE CPAREN'
+    ids = refpolicy.XpermIdentifierDict()
+    ids.set(p[4], p[8])
+
+    p[0] = refpolicy.ObjPermSet(p[4])
+    p[0].perms = set(p[8])
+
 #
 # Basic SELinux policy language
 #
@@ -1049,8 +1058,13 @@ def p_nested_xperm_list(p):
 def p_nested_xperm_element(p):
     '''nested_xperm_element : xperm_set_base
                             | nested_xperm_set
+                            | IDENTIFIER
     '''
-    p[0] = p[1]
+    if isinstance(p[1], refpolicy.XpermSet()):
+        p[0] = p[1]
+    else:
+        ids = refpolicy.XpermIdentifierDict()
+        p[0] = ids.get(p[1])
 
 def p_xperm_set_base(p):
     '''xperm_set_base : xperm_number

--- a/python/sepolgen/src/sepolgen/refpolicy.py
+++ b/python/sepolgen/src/sepolgen/refpolicy.py
@@ -413,6 +413,24 @@ class XpermSet():
 
         return "%s{ %s }" % (compl, " ".join(vals))
 
+class XpermIdentifierDict(dict):
+    """Extended permission set identifier mapping.
+
+    This singleton class holds the mappings between named
+    extended permission and their numberic value.
+    """
+    def __new__(cls):
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(XpermIdentifierDict, cls).__new__(cls)
+        return cls.instance
+
+    def set(self, key, value):
+        # TODO: warn about redefiniition
+        self[key] = value
+
+    def get(self, key):
+        return self[key]
+
 # Basic statements
 
 class TypeAttribute(Leaf):


### PR DESCRIPTION
Provide basic support for `allowxperm`, `auditallowxperm`, `dontauditxperm` and `neverallowxperm` so `/usr/bin/sepolgen-ifgen` stops spewing errors on [my policy](https://github.com/openzfs/zfs/pull/13271/files#diff-646802671c07e8d4d57cb9ddfef38332a8c5db1e04f14b4cd235a23cac3d6d09) every time `selinux-policy-targeted` gets updated.

While I would prefer additional changes to address magic numbers (e.g. a new macro, much like `interface`, but for defining xperm numbers), this PR is sufficient for my and - hopefully - the majority of the community's needs.