### PR TITLE
python/chcat: Don't fail on missing translation files

### DIFF
--- a/python/chcat/chcat
+++ b/python/chcat/chcat
@@ -40,7 +40,7 @@ try:
                     localedir="/usr/share/locale",
                     **kwargs)
     _ = t.gettext
-except ImportError:
+except:
     try:
         import builtins
         builtins.__dict__['_'] = str


### PR DESCRIPTION
Exception handling was not in line with other files, causing chcat to
fail if translation files were not available