### PR TITLE
dbus-glib has been removed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ using a custom policy please include it as well.
 There are a number of dependencies required to build the userspace
 tools/libraries. On a Fedora system you can install them with yum:
 
-    # yum install audit-libs-devel bison bzip2-devel dbus-devel dbus-glib-devel flex flex-devel flex-static glib2-devel libcap-devel libcap-ng-devel pam-devel pcre2-devel python-devel setools-devel swig ustr-devel
+    # yum install audit-libs-devel bison bzip2-devel dbus-devel flex flex-devel flex-static glib2-devel libcap-devel libcap-ng-devel pam-devel pcre2-devel python-devel setools-devel swig ustr-devel
 
 The tools and libraries can be built and installed under a private directory from the top level with make, e.g.
 


### PR DESCRIPTION
The dbus-glib's api has been replaced by GDBUS
https://github.com/SELinuxProject/selinux/commit/252925ccdffc26b89ff701ae1ae92853b338b1ff
Signed-Off-By: hongjinghao <q1204531485@163.com>