### PR TITLE
dismod: add --actions option to use dispol in non-interactive way

### DIFF
--- a/checkpolicy/test/dismod.c
+++ b/checkpolicy/test/dismod.c
@@ -66,7 +66,11 @@ static const char *symbol_labels[9] = {
 
 static __attribute__((__noreturn__)) void usage(const char *progname)
 {
-	printf("usage:  %s binary_pol_file\n\n", progname);
+	puts("Usage:");
+	printf(" %s [OPTIONS] binary_pol_file\n\n", progname);
+	puts("Options:");
+	puts(" -h, --help	print this help message");
+	puts("\n");
 	exit(1);
 }
 
@@ -868,7 +872,7 @@ int main(int argc, char **argv)
 	FILE *out_fp = stdout;
 	char ans[81], OutfileName[121];
 
-	if (argc != 2)
+	if (argc < 2 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0)
 		usage(argv[0]);
 
 	/* read the binary policy */

--- a/checkpolicy/test/dismod.c
+++ b/checkpolicy/test/dismod.c
@@ -1,4 +1,3 @@
-
 /* Authors: Frank Mayer <mayerf@tresys.com> and Karl MacMillan <kmacmillan@tresys.com>
  *
  * Copyright (C) 2003,2004,2005 Tresys Technology, LLC

--- a/checkpolicy/test/dismod.c
+++ b/checkpolicy/test/dismod.c
@@ -917,6 +917,8 @@ int main(int argc, char **argv)
 	for (;;) {
 		printf("\nCommand (\'m\' for menu):  ");
 		if (fgets(ans, sizeof(ans), stdin) == NULL) {
+			if (feof(stdin))
+				break;
 			fprintf(stderr, "fgets failed at line %d: %s\n", __LINE__,
 					strerror(errno));
 			continue;


### PR DESCRIPTION
 Example session:

    $ ./dismod --help
    Usage:
     ./dismod [OPTIONS] binary_pol_file

    Options:
     -h, --help              print this help message
     -a, --actions ACTIONS   run non-interactively

    Actions:
      1    display unconditional AVTAB
      2    display conditional AVTAB
      3    display users
      4    display bools
      5    display roles
      6    display types, attributes, and aliases
      7    display role transitions
      8    display role allows
      9    Display policycon
      0    Display initial SIDs
      a    Display avrule requirements
      b    Display avrule declarations
      c    Display policy capabilities
      u    Display the unknown handling setting
      F    Display filename_trans rules

    $ ./dismod --actions 16 input.mod
    Reading policy...
    libsepol.policydb_index_others: security:  0 users, 1 roles, 2 types, 0 bools
    libsepol.policydb_index_others: security: 0 sens, 0 cats
    libsepol.policydb_index_others: security:  1 classes, 0 rules, 0 cond rules
    libsepol.policydb_index_others: security:  0 users, 1 roles, 2 types, 0 bools
    libsepol.policydb_index_others: security: 0 sens, 0 cats
    libsepol.policydb_index_others: security:  1 classes, 0 rules, 0 cond rules
    Binary policy module file loaded.
    Module name: input
    Module version: 1.0.0
    Policy version: 21

    unconditional avtab:
    --- begin avrule block ---
    decl 1:
      allow [httpd_t] [http_port_t] : [tcp_socket] { name_bind };

     [http_port_t] [2]: type flags:0
     [httpd_t] [1]: type flags:0