### PR TITLE
setfiles: Add new argument '-y' to set a restorecon like run mode

### DIFF
--- a/policycoreutils/setfiles/setfiles.8
+++ b/policycoreutils/setfiles/setfiles.8
@@ -178,6 +178,10 @@ use up to
 threads.  Specify 0 to create as many threads as there are available
 CPU cores; 1 to use only a single thread (default); or any positive
 number to use the given number of threads (if possible).
+.TP
+.BI \-y
+run in a mode that resembles restorecon. Useful to relabel a complete system
+in initrd when no policy is loaded
 
 .SH "ARGUMENTS"
 .TP

--- a/policycoreutils/setfiles/setfiles.c
+++ b/policycoreutils/setfiles/setfiles.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 	const char *base;
 	int errors = 0;
 	const char *ropts = "e:f:hiIDlmno:pqrsvFRW0xT:";
-	const char *sopts = "c:de:f:hiIDlmno:pqr:svCEFR:W0T:";
+	const char *sopts = "c:de:f:hiIDlmno:pqr:svCEFR:W0T:y";
 	const char *opts;
 	union selinux_callback cb;
 	long unsigned skipped_errors;
@@ -264,6 +264,13 @@ int main(int argc, char **argv)
 		case 'f':
 			use_input_file = 1;
 			input_filename = optarg;
+			break;
+		case 'y':
+			r_opts.userealpath = SELINUX_RESTORECON_REALPATH;
+			r_opts.add_assoc = 0;
+			r_opts.xdev = 0;
+			r_opts.ignore_mounts = 0;
+			ctx_validate = 0;
 			break;
 		case 'd':
 			r_opts.debug = 1;


### PR DESCRIPTION
This allows to use the text representation of labels to be used for labeling in a restorecon like mode. Useful in e.g. initrd where no policy is loaded