### PR TITLE
libsemanage: fix src/genhomedircon.c build on `gcc-14` (`-Werror=allo…

### DIFF
--- a/libsemanage/src/genhomedircon.c
+++ b/libsemanage/src/genhomedircon.c
@@ -149,7 +149,7 @@ static int ignore_setup(char *ignoredirs) {
 
 	tok = strtok(ignoredirs, ";");
 	while(tok) {
-		ptr = calloc(sizeof(ignoredir_t),1);
+		ptr = calloc(1, sizeof(ignoredir_t));
 		if (!ptr)
 			goto err;
 		ptr->dir = strdup(tok);


### PR DESCRIPTION
…c-size`)

`gcc-14` added a new `-Walloc-size` warning that makes sure that size of an individual element matches size of a pointed type:

    https://gcc.gnu.org/PR71219

`libsemanage` triggers it on `calloc()` calls where member size is used as `1` (instead of member count):

    genhomedircon.c: In function 'ignore_setup':
    genhomedircon.c:152:21:
      error: allocation of insufficient size '1' for type 'ignoredir_t'
        {aka 'struct IgnoreDir'} with size '16' [-Werror=alloc-size]
      152 |                 ptr = calloc(sizeof(ignoredir_t),1);
          |                     ^