### PR TITLE
libsepol/src/Makefile: fix reallocarray detection

### DIFF
--- a/libsepol/src/Makefile
+++ b/libsepol/src/Makefile
@@ -31,7 +31,7 @@ endif
 
 # check for reallocarray(3) availability
 H := \#
-ifeq (yes,$(shell printf '${H}define _GNU_SOURCE\n${H}include <stdlib.h>\nint main(void){void*p=reallocarray(NULL, 1, sizeof(char));return 0;}' | $(CC) -x c -o /dev/null - >/dev/null 2>&1 && echo yes))
+ifeq (yes,$(shell printf '${H}define _GNU_SOURCE\n${H}include <stdlib.h>\nint main(void){void*p=reallocarray(NULL, 1, sizeof(char));return 0;}' | $(CC) $(LDFLAGS) -x c -o /dev/null - >/dev/null 2>&1 && echo yes))
 override CFLAGS += -DHAVE_REALLOCARRAY
 endif
 


### PR DESCRIPTION
Pass `LDFLAGS` when checking for reallocarray to avoid the following static build failure with musl raised since version 3.4 and https://github.com/SELinuxProject/selinux/commit/f0a5f6e33084bd83d409bb7c932256139f471e71 because `-static` is not passed when checking for reallocarray:

```
/home/autobuild/autobuild/instance-9/output-1/host/bin/armeb-buildroot-linux-musleabi-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64  -O0 -g0  -static -I. -I../include -D_GNU_SOURCE -I../cil/include -fPIC -c -o assertion.o assertion.c In file included from assertion.c:28:
private.h:88:21: error: static declaration of 'reallocarray' follows non-static declaration
   88 | static inline void* reallocarray(void *ptr, size_t nmemb, size_t size) {
      |                     ^~~~~~~~~~~~
In file included from ../include/sepol/policydb/mls_types.h:35,
                 from ../include/sepol/policydb/context.h:23,
                 from ../include/sepol/policydb/policydb.h:62,
                 from assertion.c:24:
/home/autobuild/autobuild/instance-9/output-1/host/armeb-buildroot-linux-musleabi/sysroot/usr/include/stdlib.h:150:7: note: previous declaration of 'reallocarray' with type 'void *(void *, size_t,  size_t)' {aka 'void *(void *, unsigned int,  unsigned int)'}
  150 | void *reallocarray (void *, size_t, size_t);
      |       ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/0170032548a38e2c991d62dc5823808458ad03b3