### PR TITLE
fix selabel_digest set baseonly error

### DIFF
--- a/libselinux/utils/selabel_digest.c
+++ b/libselinux/utils/selabel_digest.c
@@ -73,8 +73,8 @@ int main(int argc, char **argv)
 	struct selabel_handle *hnd;
 	struct selinux_opt selabel_option[] = {
 		{ SELABEL_OPT_PATH, file },
-		{ SELABEL_OPT_BASEONLY, baseonly },
-		{ SELABEL_OPT_DIGEST, digest }
+		{ SELABEL_OPT_DIGEST, digest },
+		{ SELABEL_OPT_BASEONLY, baseonly }
 	};
 
 	if (argc < 3)
@@ -121,10 +121,10 @@ int main(int argc, char **argv)
 	memset(cmd_buf, 0, sizeof(cmd_buf));
 
 	selabel_option[0].value = file;
-	selabel_option[1].value = baseonly;
-	selabel_option[2].value = digest;
+	selabel_option[1].value = digest;
+	selabel_option[2].value = baseonly;
 
-	hnd = selabel_open(backend, selabel_option, 3);
+	hnd = selabel_open(backend, selabel_option, (backend == SELABEL_CTX_FILE ? 3 : 2));
 	if (!hnd) {
 		switch (errno) {
 		case EOVERFLOW:


### PR DESCRIPTION
to fix issue：
https://github.com/SELinuxProject/selinux/issues/427

Verify as follows:
```
[root@localhost ~]# selabel_digest -b x
SHA1 digest: f9507fe47c6df8d8a9fb9ff0656cb1397b69fcb1
calculated using the following specfile(s):
/etc/selinux/targeted/contexts/x_contexts
[root@localhost ~]# 
[root@localhost ~]# selabel_digest -b media
SHA1 digest: 4241384aa031191cb0596c41973645dd9ea61fca
calculated using the following specfile(s):
/etc/selinux/targeted/contexts/files/media
[root@localhost ~]# 
[root@localhost ~]# selabel_digest -b db
SHA1 digest: 382767b9b6575d5e142f0d429991c84c21a7d64a
calculated using the following specfile(s):
/etc/selinux/targeted/contexts/sepgsql_contexts
[root@localhost ~]# 
```
