### PR TITLE
libselinux/src/se_linux_internal.c: include stdint.h

### DIFF
--- a/libselinux/src/selinux_internal.c
+++ b/libselinux/src/selinux_internal.c
@@ -1,6 +1,7 @@
 #include "selinux_internal.h"
 
 #include <errno.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
Include `stdint.h` to avoid the following uclibc build failure raised since version 3.6 and https://github.com/SELinuxProject/selinux/commit/cb8289c2b237e5f66e4a7608ecc6c68abeaeaf55:

```
selinux_internal.c: In function 'reallocarray':
selinux_internal.c:25:29: error: 'SIZE_MAX' undeclared (first use in this function)
   25 |         if (size && nmemb > SIZE_MAX / size) {
      |                             ^~~~~~~~
selinux_internal.c:6:1: note: 'SIZE_MAX' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
    5 | #include <string.h>
  +++ |+#include <stdint.h>
    6 |
selinux_internal.c:25:29: note: each undeclared identifier is reported only once for each function it appears in
   25 |         if (size && nmemb > SIZE_MAX / size) {
      |                             ^~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/7e627744beaa4f7fdfd488dfacbaafc074a999f7