### PR TITLE
libsepol: make reallocarray check more robust

### DIFF
--- a/libsepol/src/Makefile
+++ b/libsepol/src/Makefile
@@ -31,7 +31,7 @@ endif
 
 # check for reallocarray(3) availability
 H := \#
-ifeq (yes,$(shell printf '${H}include <stdlib.h>\nint main(void){return reallocarray(NULL,0,0)==NULL;}' | $(CC) $(CFLAGS) $(LDFLAGS) -x c -o /dev/null - >/dev/null 2>&1 && echo yes))
+ifeq (yes,$(shell printf '${H}include <stdlib.h>\nint main(void){return reallocarray(NULL,0,0)==NULL;}' | $(CC) $(CFLAGS) $(LDFLAGS) -x c - >/dev/null 2>&1 && echo yes))
 override CFLAGS += -DHAVE_REALLOCARRAY
 endif
 


### PR DESCRIPTION
Some cross-compiler toolchains dislike the usage of -o /dev/null and fail with: ld: final link failed: file truncated

As stdin and stdout is already redirected to /dev/null there is no need for gcc -o /dev/null.

This fixes an Buildroot autobuild failure for libsepol package: http://autobuild.buildroot.net/results/72b/72baaab4658254f4c5b3348298af1d5c891cacd6/