### PR TITLE
libsemanage: Mimic GNU basename() API for non-glibc library e.g. musl

### DIFF
--- a/libsemanage/src/direct_api.c
+++ b/libsemanage/src/direct_api.c
@@ -63,6 +63,9 @@
 #define PIPE_READ 0
 #define PIPE_WRITE 1
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#if !defined(__GLIBC__)
+#define basename(src) (strrchr(src, '/') ? strrchr(src, '/') + 1 : src)
+#endif
 
 static void semanage_direct_destroy(semanage_handle_t * sh);
 static int semanage_direct_disconnect(semanage_handle_t * sh);


### PR DESCRIPTION
musl only provides POSIX version of basename and it has also removed providing it via string.h header [1] which now results in compile errors with newer compilers e.g. clang-18

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7