### PR TITLE
libselinux: Do not clobber errno of the world

### DIFF
--- a/libselinux/src/init.c
+++ b/libselinux/src/init.c
@@ -146,6 +146,7 @@ void set_selinuxmnt(const char *mnt)
 static void init_lib(void) __attribute__ ((constructor));
 static void init_lib(void)
 {
+	SELINUX_PROTECT_ERRNO;
 	selinux_page_size = sysconf(_SC_PAGE_SIZE);
 	init_selinuxmnt();
 #ifndef ANDROID

--- a/libselinux/src/selinux_internal.h
+++ b/libselinux/src/selinux_internal.h
@@ -3,6 +3,7 @@
 
 #include <selinux/selinux.h>
 #include <pthread.h>
+#include <errno.h>
 
 
 extern int require_seusers ;
@@ -131,4 +132,13 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size);
 #define IGNORE_DEPRECATED_DECLARATION_END
 #endif
 
+static inline void selinux_reset_errno(int *saved_errno) {
+        if (*saved_errno < 0)
+                return;
+
+        errno = *saved_errno;
+}
+
+#define SELINUX_PROTECT_ERRNO __attribute__((__cleanup__(selinux_reset_errno))) \
+                         __attribute__((__unused__)) int __selinux_saved_errno = errno
 #endif /* SELINUX_INTERNAL_H_ */


### PR DESCRIPTION
libselinux clobbers errno of all consumers (systemd, sshd you name it) because its constructors do not properly save and restore errno. The following program demonstrates it.

int main(void)
{
        assert(errno == 0);
	/* Just a test, it doesn't matter already clobbered */
        if(is_selinux_enabled() < 0) {
                perror("not enabled");
                return 1;
        }
}

if any function sets errno, it is not switched back to the original value and standards DO NOT require errno to the set to zero before entering main