### PR TITLE
libselinux,libsepol: Honor PREFIX for shared libraries

### DIFF
--- a/libselinux/src/Makefile
+++ b/libselinux/src/Makefile
@@ -10,7 +10,7 @@ PKG_CONFIG ?= pkg-config
 # Installation directories.
 PREFIX ?= /usr
 LIBDIR ?= $(PREFIX)/lib
-SHLIBDIR ?= /lib
+SHLIBDIR ?= $(PREFIX)/lib
 INCLUDEDIR ?= $(PREFIX)/include
 PYINC ?= $(shell $(PKG_CONFIG) --cflags $(PYPREFIX))
 PYLIBS ?= $(shell $(PKG_CONFIG) --libs $(PYPREFIX))

--- a/libsepol/src/Makefile
+++ b/libsepol/src/Makefile
@@ -2,7 +2,7 @@
 PREFIX ?= /usr
 INCLUDEDIR ?= $(PREFIX)/include
 LIBDIR ?= $(PREFIX)/lib
-SHLIBDIR ?= /lib
+SHLIBDIR ?= $(PREFIX)/lib
 RANLIB ?= ranlib
 CILDIR ?= ../cil
 


### PR DESCRIPTION
Use `PREFIX` in `SHLIBDIR` just like for the other directories. Without this, local user installs with `PREFIX` set but not `DESTDIR` attempt to write to system locations.