### PR TITLE
Don't inject matchpathcon_filespec_add64() ifdef __x86_64__ (#463, Debian#1098481)

### DIFF
--- a/libselinux/include/selinux/selinux.h
+++ b/libselinux/include/selinux/selinux.h
@@ -537,7 +537,7 @@ extern int matchpathcon_index(const char *path,
    with the same inode (e.g. due to multiple hard links).  If so, then
    use the latter of the two specifications based on their order in the 
    file contexts configuration.  Return the used specification index. */
-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
+#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && !defined(__INO_T_MATCHES_INO64_T)
 #define matchpathcon_filespec_add matchpathcon_filespec_add64
 #endif
 extern int matchpathcon_filespec_add(ino_t ino, int specind, const char *file);

--- a/libselinux/src/matchpathcon.c
+++ b/libselinux/src/matchpathcon.c
@@ -261,7 +261,7 @@ int matchpathcon_filespec_add(ino_t ino, int specind, const char *file)
 	return -1;
 }
 
-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
+#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) && !defined(__INO_T_MATCHES_INO64_T)
 /* alias defined in the public header but we undefine it here */
 #undef matchpathcon_filespec_add
 
@@ -280,9 +280,13 @@ int matchpathcon_filespec_add(unsigned long ino, int specind,
 {
 	return matchpathcon_filespec_add64(ino, specind, file);
 }
+#elif (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || defined(__INO_T_MATCHES_INO64_T)
+
+static_assert(sizeof(uint64_t) == sizeof(ino_t), "inode size mismatch");
+
 #else
 
-static_assert(sizeof(unsigned long) == sizeof(ino_t), "inode size mismatch");
+static_assert(sizeof(uint32_t) == sizeof(ino_t), "inode size mismatch");
 
 #endif
 

--- a/libsemanage/src/Makefile
+++ b/libsemanage/src/Makefile
@@ -60,7 +60,7 @@ CFLAGS ?= -Werror -Wall -W -Wundef -Wshadow -Wmissing-noreturn -Wmissing-format-
 SWIG_CFLAGS += -Wno-error -Wno-unused-but-set-variable -Wno-unused-variable -Wno-shadow \
 		-Wno-unused-parameter -Wno-missing-prototypes
 
-override CFLAGS += -I../include -D_GNU_SOURCE
+override CFLAGS += -I../include -I../../libselinux/include -D_GNU_SOURCE
 RANLIB ?= ranlib
 
 SWIG = swig -Wall -python -o $(SWIGCOUT) -outdir ./
@@ -90,7 +90,7 @@ $(LIBA): $(OBJS)
 	$(RANLIB) $@
 
 $(LIBSO): $(LOBJS)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -o $@ $^ -lsepol -laudit -lselinux -lbz2 -Wl,-soname,$(LIBSO),--version-script=libsemanage.map,-z,defs
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -o $@ $^ -L../../libselinux/src -lsepol -laudit -lselinux -lbz2 -Wl,-soname,$(LIBSO),--version-script=libsemanage.map,-z,defs
 	ln -sf $@ $(TARGET)
 
 $(LIBPC): $(LIBPC).in ../VERSION

--- a/mcstrans/src/Makefile
+++ b/mcstrans/src/Makefile
@@ -16,6 +16,8 @@ PROG_OBJS= $(patsubst %.c,%.o,$(PROG_SRC))
 PROG=mcstransd
 INITSCRIPT=mcstrans
 CFLAGS ?= -Wall -W -Wundef -Wmissing-noreturn -Wmissing-format-attribute
+override CFLAGS += -I../../libselinux/include
+override LDFLAGS+= -L../../libselinux/src
 
 all: $(PROG)
 

--- a/mcstrans/utils/Makefile
+++ b/mcstrans/utils/Makefile
@@ -2,6 +2,9 @@
 PREFIX ?= /usr
 SBINDIR ?= $(PREFIX)/sbin
 
+override CFLAGS += -I../../libselinux/include
+override LDFLAGS+= -L../../libselinux/src
+
 TARGETS=transcon untranscon
 
 # If no specific libsepol.a is specified, fall back on LDFLAGS search path

--- a/policycoreutils/load_policy/Makefile
+++ b/policycoreutils/load_policy/Makefile
@@ -6,7 +6,7 @@ MANDIR ?= $(PREFIX)/share/man
 LOCALEDIR ?= $(DESTDIR)$(PREFIX)/share/locale
 
 CFLAGS ?= -Werror -Wall -W
-override CFLAGS += $(LDFLAGS) -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
+override CFLAGS += $(LDFLAGS) -I../../libselinux/include -L../../libselinux/src -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
 override LDLIBS += -lsepol -lselinux
 
 TARGETS=$(patsubst %.c,%,$(sort $(wildcard *.c)))

--- a/policycoreutils/newrole/Makefile
+++ b/policycoreutils/newrole/Makefile
@@ -24,7 +24,8 @@ VERSION = $(shell cat ../VERSION)
 
 CFLAGS ?= -Werror -Wall -W
 EXTRA_OBJS =
-override CFLAGS += -DVERSION=\"$(VERSION)\" -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
+override CFLAGS += -I../../libselinux/include -DVERSION=\"$(VERSION)\" -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux
 ifeq ($(PAMH), y)
 	override CFLAGS += -DUSE_PAM

--- a/policycoreutils/run_init/Makefile
+++ b/policycoreutils/run_init/Makefile
@@ -10,7 +10,8 @@ PAMH ?= $(shell test -f /usr/include/security/pam_appl.h && echo y)
 AUDITH ?= $(shell test -f /usr/include/libaudit.h && echo y)
 
 CFLAGS ?= -Werror -Wall -W
-override CFLAGS += -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
+override CFLAGS += -I../../libselinux/include -DUSE_NLS -DLOCALEDIR="\"$(LOCALEDIR)\"" -DPACKAGE="\"policycoreutils\""
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux
 ifeq ($(PAMH), y)
 	override CFLAGS += -DUSE_PAM

--- a/policycoreutils/secon/Makefile
+++ b/policycoreutils/secon/Makefile
@@ -7,7 +7,8 @@ MANDIR ?= $(PREFIX)/share/man
 WARNS=-Werror -W -Wall -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-align -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wnested-externs -Wno-format-zero-length -Wformat-nonliteral -Wformat-security -Wfloat-equal
 VERSION = $(shell cat ../VERSION)
 CFLAGS ?= $(WARNS) -O1
-override CFLAGS += -DVERSION=\"$(VERSION)\"
+override CFLAGS += -I../../libselinux/include -DVERSION=\"$(VERSION)\"
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux
 
 all: secon

--- a/policycoreutils/semodule/Makefile
+++ b/policycoreutils/semodule/Makefile
@@ -5,6 +5,8 @@ SBINDIR ?= $(PREFIX)/sbin
 MANDIR = $(PREFIX)/share/man
 
 CFLAGS ?= -Werror -Wall -W
+override CFLAGS += -I../../libselinux/include -I../../libsemanage/include
+override LDFLAGS+= -L../../libselinux/src     -L../../libsemanage/src
 override LDLIBS += -lsepol -lselinux -lsemanage
 SEMODULE_OBJS = semodule.o
 

--- a/policycoreutils/sestatus/Makefile
+++ b/policycoreutils/sestatus/Makefile
@@ -7,7 +7,8 @@ MANDIR = $(PREFIX)/share/man
 ETCDIR ?= /etc
 
 CFLAGS ?= -Werror -Wall -W
-override CFLAGS += -D_FILE_OFFSET_BITS=64
+override CFLAGS += -I../../libselinux/include -D_FILE_OFFSET_BITS=64
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux
 
 all: sestatus

--- a/policycoreutils/setfiles/Makefile
+++ b/policycoreutils/setfiles/Makefile
@@ -6,6 +6,8 @@ MANDIR = $(PREFIX)/share/man
 AUDITH ?= $(shell test -f /usr/include/libaudit.h && echo y)
 
 CFLAGS ?= -g -Werror -Wall -W
+override CFLAGS += -I../../libselinux/include
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux -lsepol -lpthread
 
 ifeq ($(AUDITH), y)

--- a/policycoreutils/setsebool/Makefile
+++ b/policycoreutils/setsebool/Makefile
@@ -6,6 +6,8 @@ MANDIR = $(PREFIX)/share/man
 BASHCOMPLETIONDIR ?= $(PREFIX)/share/bash-completion/completions
 
 CFLAGS ?= -Werror -Wall -W
+override CFLAGS += -I../../libselinux/include -I../../libsemanage/include
+override LDFLAGS+= -L../../libselinux/src     -L../../libsemanage/src
 override LDLIBS += -lselinux -lsemanage
 SETSEBOOL_OBJS = setsebool.o
 

--- a/policycoreutils/unsetfiles/Makefile
+++ b/policycoreutils/unsetfiles/Makefile
@@ -2,7 +2,8 @@ PREFIX ?= /usr
 SBINDIR ?= $(PREFIX)/sbin
 MANDIR ?= $(PREFIX)/share/man
 
-override CFLAGS += -D_GNU_SOURCE
+override CFLAGS += -I../../libselinux/include -D_GNU_SOURCE
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux
 
 

--- a/python/audit2allow/Makefile
+++ b/python/audit2allow/Makefile
@@ -8,6 +8,8 @@ BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
 
 CFLAGS ?= -Werror -Wall -W
+override CFLAGS += -I../../libselinux/include
+override LDFLAGS+= -L../../libselinux/src
 
 # If no specific libsepol.a is specified, fall back on LDFLAGS search path
 # Otherwise, as $(LIBSEPOLA) already appears in the dependencies, there

--- a/restorecond/Makefile
+++ b/restorecond/Makefile
@@ -18,8 +18,8 @@ GIO_CFLAGS = -DHAVE_DBUS $(shell $(PKG_CONFIG) --cflags gio-2.0)
 GIO_LIBS = $(shell $(PKG_CONFIG) --libs gio-2.0)
 
 CFLAGS ?= -g -Werror -Wall -W
-override CFLAGS += $(GIO_CFLAGS)
-
+override CFLAGS += -I../../libselinux/include $(GIO_CFLAGS)
+override LDFLAGS+= -L../../libselinux/src
 override LDLIBS += -lselinux $(GIO_LIBS)
 
 all: restorecond


### PR DESCRIPTION
As the code notes, it wants to add an
```c
/* ABI backwards-compatible shim for non-LFS 32-bit systems */
```
it tries to detect these with
```c
#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
```
which is correct with the added precondition that the `ino_t` *without*
`-D_FILE_OFFSET_BITS=64` *was actually* u32 (i.e. it conflates *all* ILP32 systems into being non-LFS).

This is not the case on x32, for example, which is LFS; thus, the
```c
static_assert(sizeof(unsigned long) == sizeof(__ino_t), "inode size mismatch");
```
assertion fails (`__ino_t` is the "kernel ino_t" type, which generally corresponds to the kernel's ulong, which is u64 on x32).

The correct spelling of the test for this is
```c
#if ... && sizeof(__ino_t) == 4
```
but this is not statically solvable with the preprocessor.

Thus, we need to explicitly special-case this. `__x86_64__` indicates one of two ABIs (LP64 (amd64) or ILP32 (x32)), both of which have ino_t=u64, and is the macro used for defining `__INO_T_TYPE` in the system headers, so it's the best fit here.

Fixes: commit 9395cc0322 ("Always build for LFS mode on 32-bit archs.")
Closes: #463
Closes: Debian#1098481
Cc: @kainz

---

Insert -I../../libselinux/include and -L../../libselinux/src into subprograms where needed

These subprograms (sublibraries) use plain
```
#include <selinux/selinux.h>
cc ... -lselinux ...
```
&c. which includes/links to the system libselinux.

Naturally, this doesn't work if you don't have one.

These all came out of a plain build on x32.