### PR TITLE
policycoreutils: run_init: define _GNU_SOURCE

### DIFF
--- a/policycoreutils/run_init/run_init.c
+++ b/policycoreutils/run_init/run_init.c
@@ -37,6 +37,8 @@
  *
  *************************************************************************/
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>		/* for malloc(), realloc(), free() */
 #include <pwd.h>		/* for getpwuid() */


### PR DESCRIPTION
Trying to compile run_init with musl will fail with: run_init.c: In function 'authenticate_via_shadow_passwd': run_init.c:206:40: error: implicit declaration of function 'getpass' [-Wimplicit-function-declaration]
  206 |         if (!(unencrypted_password_s = getpass(PASSWORD_PROMPT))) {

This is because getpass in musl is guarded only for _GNU_SOURCE, so define _GNU_SOURCE for run_init.


[Thomas: taken from OpenWrt at
https://git.infobricfleet.com/gtu/openwrt/-/blob/e56845fae3c05463a57ba8e0e104d6d8d8cd96ed/package/utils/policycoreutils/patches/0001-policycoreutils-run_init-define-_GNU_SOURCE.patch]