### PR TITLE
libselinux: add selinux_unshare() and is_selinux_unshared()

### DIFF
--- a/libselinux/include/selinux/selinux.h
+++ b/libselinux/include/selinux/selinux.h
@@ -760,6 +760,29 @@ extern int selinux_lsetfilecon_default(const char *path);
  */
 extern void selinux_reset_config(void);
 
+/*
+ * Unshare the SELinux namespace.
+ * Prior to invoking this API, the caller must have unshared the
+ * mount namespace (CLONE_NEWNS) and mounted a MS_REC|MS_PRIVATE
+ * / filesystem so that selinux_unshare() can freely modify any
+ * existing selinuxfs mount as needed for the unshare.
+ * Returns 0 on success, in which case the SELinux namespace has
+ * been unshared and any old selinuxfs mount will have been unmounted.
+ * The caller can then proceed to mount a new selinuxfs filesystem
+ * for the new namespace, load a policy, set enforcing mode, etc.
+ */
+extern int selinux_unshare(void);
+
+/*
+ * Returns 1 if the SELinux namespace was unshared and has not
+ * yet been fully initialized (i.e. policy not yet loaded).
+ * Returns 0 if SELinux namespaces are not supported by the kernel,
+ * or the SELinux namespace was not unshared, or the namespace has
+ * been fully initialized already.
+ * Return < 0 on any error other than ENOSYS or EOPNOTSUPP.
+ */
+extern int is_selinux_unshared(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libselinux/src/libselinux.map
+++ b/libselinux/src/libselinux.map
@@ -262,3 +262,9 @@ LIBSELINUX_3.9 {
   global:
     context_to_str;
 } LIBSELINUX_3.8;
+
+LIBSELINUX_4.0 {
+  global:
+    selinux_unshare;
+    is_selinux_unshared;
+} LIBSELINUX_3.9;

--- a/libselinux/src/unshare.c
+++ b/libselinux/src/unshare.c
@@ -1,0 +1,117 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/mount.h>
+#include <sys/vfs.h>
+#include <sys/statvfs.h>
+#include <sys/syscall.h>
+#include <linux/lsm.h>
+
+#include "selinux_internal.h"
+#include "policy.h"
+
+#ifndef LSM_ATTR_UNSHARE
+#define LSM_ATTR_UNSHARE 106
+#endif
+
+#ifndef __NR_lsm_get_self_attr
+#define __NR_lsm_get_self_attr 459
+#endif
+
+#ifndef __NR_lsm_set_self_attr
+#define __NR_lsm_set_self_attr 460
+#endif
+
+#ifndef HAVE_LSM_SET_SELF_ATTR
+#define HAVE_LSM_SET_SELF_ATTR 1
+static int lsm_set_self_attr(unsigned int attr, struct lsm_ctx *ctx,
+			     uint32_t size, uint32_t flags)
+{
+	return syscall(__NR_lsm_set_self_attr, attr, ctx, size, flags);
+}
+#endif
+
+#ifndef HAVE_LSM_GET_SELF_ATTR
+#define HAVE_LSM_GET_SELF_ATTR 1
+static int lsm_get_self_attr(unsigned int attr, struct lsm_ctx *ctx,
+			     uint32_t *size, uint32_t flags)
+{
+	return syscall(__NR_lsm_get_self_attr, attr, ctx, size, flags);
+}
+#endif
+
+/*
+ * Precondition: caller must have already done unshare(CLONE_NEWNS) or
+ * been created via clone(CLONE_NEWNS) and mounted a MS_REC|MS_PRIVATE
+ * / filesystem so that any pre-existing selinuxfs mount can be
+ * modified freely by selinux_unshare(). See ../utils/unshareselinux.c
+ * for an example.
+ */
+int selinux_unshare(void)
+{
+	struct lsm_ctx ctx;
+	int ret;
+
+	ctx.id = LSM_ID_SELINUX;
+	ctx.flags = 0;
+	ctx.len = sizeof(ctx);
+	ctx.ctx_len = 0;
+
+	/* Unshare the SELinux namespace */
+	ret = lsm_set_self_attr(LSM_ATTR_UNSHARE, &ctx, sizeof(ctx), 0);
+	if (ret < 0)
+		return -1;
+
+	/* Unmount the selinuxfs which refers to the old/parent namespace */
+	ret = umount(SELINUXMNT);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * Caller is responsible for mounting new selinuxfs, loading policy,
+	 * setting enforcing mode, etc.
+	 */
+
+	return 0;
+}
+
+struct selinux_ctx {
+	struct lsm_ctx lsmctx;
+	char unshared;
+};
+
+/*
+ * Returns 1 if the SELinux namespace was unshared and has not
+ * yet been fully initialized (i.e. policy not yet loaded).
+ * Returns 0 if SELinux namespaces are not supported by the kernel,
+ * or the SELinux namespace was not unshared, or the namespace has
+ * been fully initialized already.
+ * Return < 0 on any error other than ENOSYS or EOPNOTSUPP.
+ */
+int is_selinux_unshared(void)
+{
+	struct selinux_ctx ctx;
+	uint32_t size = sizeof(ctx);
+	int ret;
+
+	ctx.lsmctx.id = LSM_ID_SELINUX;
+	ctx.lsmctx.flags = 0;
+	ctx.lsmctx.len = sizeof(ctx);
+	ctx.lsmctx.ctx_len = 0;
+
+	ret = lsm_get_self_attr(LSM_ATTR_UNSHARE, (struct lsm_ctx *)&ctx,
+				&size, LSM_FLAG_SINGLE);
+	if (ret < 0 && (errno == ENOSYS || errno == EOPNOTSUPP))
+		return 0;
+	if (ret < 0)
+		return ret;
+	return ctx.unshared;
+}

--- a/libselinux/utils/.gitignore
+++ b/libselinux/utils/.gitignore
@@ -30,3 +30,5 @@ setfilecon
 togglesebool
 selinux_check_access
 validatetrans
+unshareselinux
+selinuxunshared

--- a/libselinux/utils/selinuxunshared.c
+++ b/libselinux/utils/selinuxunshared.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <selinux/selinux.h>
+
+int main(int argc, char **argv)
+{
+	int ret;
+
+	if (argc != 1) {
+		fprintf(stderr, "usage: %s\n", argv[0]);
+		exit(-1);
+	}
+
+	ret = is_selinux_unshared();
+	if (ret < 0) {
+		perror(argv[0]);
+		exit(-1);
+	}
+
+	printf("%d\n", ret);
+
+	exit(!ret);
+}

--- a/libselinux/utils/unshareselinux.c
+++ b/libselinux/utils/unshareselinux.c
@@ -1,0 +1,43 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/mount.h>
+#include <selinux/selinux.h>
+
+int main(int argc, char **argv)
+{
+	int ret;
+
+	ret = unshare(CLONE_NEWNS);
+	if (ret < 0) {
+		perror("unshare(CLONE_NEWNS)");
+		exit(1);
+	}
+
+	ret = mount("none", "/", NULL, MS_REC | MS_PRIVATE, NULL);
+	if (ret < 0) {
+		perror("mount(/)");
+		exit(1);
+	}
+
+	ret = selinux_unshare();
+	if (ret < 0) {
+		perror("selinux_unshare");
+		exit(1);
+	}
+
+	if (argc < 2) {
+		fprintf(stderr, "usage: %s command args...\n", argv[0]);
+		exit(1);
+	}
+
+	execvp(argv[1], &argv[1]);
+	perror(argv[1]);
+	exit(1);
+}


### PR DESCRIPTION
Provide a selinux_unshare() wrapper for
lsm_set_self_attr(LSM_ATTR_UNSHARE, ...) and other required processing when unsharing the SELinux namespace, and an is_selinux_unshared() wrapper for lsm_get_self_attr(LSM_ATTR_UNSHARE, ...) for detecting whether one is in an unshared SELinux namespace that has not yet been fully initialized.

Add a selinux_unshare() interface to unshare the SELinux namespace, and an unshareselinux utility to run a shell or command in its own SELinux and mount namespaces. The selinux_unshare() interface expects the caller to have already unshared its mount namespace and created a MS_REC|MS_PRIVATE mount of / prior to invoking it so that it can freely modify the selinuxfs mount as needed by the unshare operation. The unshareselinux utility demonstrates how to do this prior to calling selinux_unshare(). Upon a successful return from selinux_unshare(), the SELinux namespace will be unshared and there will be no selinuxfs mount on /sys/fs/selinux. The caller can then proceed to mount a new selinuxfs filesystem private to the new namespace, load a policy, set enforcing mode, etc, as is commonly handled by init/systemd during boot.

Add an is_selinux_unshared() interface to detect whether one is in an unshared SELinux namespace that has not yet been fully initialized (i.e. no policy loaded yet), and a selinuxunshared utility to use it from a shell or script. The is_selinux_unshared() interface returns 1 iff the SELinux namespace has been unshared and has not yet been fully initialized. It returns 0 if SELinux namespaces are not supported or the namespace has not been unshared or the namespace has been fully initialized. If lsm_get_self_attr(2) return -1 with an errno other than ENOSYS (not implemented) or EOPNOTSUPP (not supported by any active LSM), then is_selinux_unshared() will return -1 with the same errno.

Please read [CONTRIBUTING.md](https://github.com/SELinuxProject/selinux/blob/main/CONTRIBUTING.md)

## Contributing Code

Post the patch for the review to the
[SELinux mailing list](https://lore.kernel.org/selinux) at
[selinux@vger.kernel.org](mailto:selinux@vger.kernel.org).

When preparing patches, please follow these guidelines:

-   Patches should apply with git am
-   Must apply against HEAD of the main branch
-   Separate large patches into logical patches
-   Patch descriptions must end with your "Signed-off-by" line. This means your
    code meets the Developer's certificate of origin, see below.
