### PR TITLE
policycoreutils/secon: fix discarded-qualifiers warning with glibc 2.43

### DIFF
--- a/policycoreutils/secon/secon.c
+++ b/policycoreutils/secon/secon.c
@@ -348,7 +348,7 @@ static int my_getXcon_raw(pid_t pid, char  **con, const char *val)
 {
 	char buf[4096];
 	FILE *fp = NULL;
-	const char *ptr = NULL;
+	char *ptr = NULL;
 
 	snprintf(buf, sizeof(buf), "%s/%ld/attr/%s", "/proc", (long int)pid,
 		 val);


### PR DESCRIPTION
## Problem

In `my_getXcon_raw()`, `ptr` is declared as `const char *` but is
assigned from `fgets()`, which returns `char *`. With glibc 2.43,
`strchr(const char *, int)` now correctly returns `const char *`
(matching the constness of its input), so the subsequent assignment
to `char *tmp` triggers a build failure:

```
secon.c: In function 'my_getXcon_raw':
secon.c:365:18: error: initialization discards 'const' qualifier from
pointer target type [-Werror=discarded-qualifiers]
  365 |         char *tmp = strchr(ptr, '\n');
      |                     ^~~~~~
```

This breaks builds on any system with glibc 2.43+ and gcc with
`-Werror` (which the SELinux Makefile uses).

## Fix

The `const` on `ptr` was always incorrect:

- `fgets()` returns `char *` (a mutable pointer into `buf`, which is
  `char[4096]`)
- The result of `strchr()` through `ptr` is immediately used mutably:
  `*tmp = 0`

Remove the erroneous `const` qualifier from `ptr`.

## Relation to issue #506

This is the same class of bug reported in #506
(`libselinux/src/selinux_config.c:284`). That issue covers
`strrchr()` in `selinux_set_policy_root()`; this patch covers
`strchr()` in `my_getXcon_raw()` in `policycoreutils/secon/secon.c`.

Both instances have the same root cause: a local variable was
unnecessarily `const`-qualified, which glibc 2.43's strengthened
`strchr`/`strrchr` const-propagation now correctly rejects.

## Testing

Verified by building `policycoreutils` version 3.10 against glibc 2.43
on a Wolfi-based system (Chainguard) where this was a build failure.

Signed-off-by: Dustin Kirkland <dustin.kirkland@chainguard.dev>