### PR TITLE
expose alias for stat64 and lstat64 on musl

### DIFF
--- a/libselinux/src/selinux_restorecon.c
+++ b/libselinux/src/selinux_restorecon.c
@@ -19,7 +19,6 @@
 #include <limits.h>
 #include <stdint.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <sys/xattr.h>
 #include <sys/vfs.h>
 #include <sys/statvfs.h>
@@ -28,6 +27,10 @@
 #include <libgen.h>
 #include <syslog.h>
 #include <assert.h>
+
+// expose alias for stat64 and lstat64 on musl
+#define _LARGEFILE64_SOURCE 1
+#include <sys/stat.h>
 
 #include <selinux/selinux.h>
 #include <selinux/context.h>


### PR DESCRIPTION
provide alias for `stat64` and `lstat64` for use in `filespec_add`:

https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/selinux_restorecon.c#L440-L446
https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/selinux_restorecon.c#L456-L460

fix: #477
