### PR TITLE
define matchpathcon_filespec_add/add64

### DIFF
--- a/libselinux/include/selinux/selinux.h
+++ b/libselinux/include/selinux/selinux.h
@@ -537,10 +537,8 @@ extern int matchpathcon_index(const char *path,
    with the same inode (e.g. due to multiple hard links).  If so, then
    use the latter of the two specifications based on their order in the 
    file contexts configuration.  Return the used specification index. */
-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && defined(__INO64_T_TYPE) && !defined(__INO_T_MATCHES_INO64_T)
-#define matchpathcon_filespec_add matchpathcon_filespec_add64
-#endif
 extern int matchpathcon_filespec_add(ino_t ino, int specind, const char *file);
+extern int matchpathcon_filespec_add64(ino_t ino, int specind, const char *file);
 
 /* Destroy any inode associations that have been added, e.g. to restart
    for a new filesystem. */

--- a/libselinux/src/matchpathcon.c
+++ b/libselinux/src/matchpathcon.c
@@ -261,25 +261,20 @@ int matchpathcon_filespec_add(ino_t ino, int specind, const char *file)
 	return -1;
 }
 
+int matchpathcon_filespec_add64(unsigned long ino, int specind,
+                              const char *file)
+{
+	return matchpathcon_filespec_add(ino, specind, file);
+}
+
 #if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) && defined(__INO64_T_TYPE) && !defined(__INO_T_MATCHES_INO64_T)
-/* alias defined in the public header but we undefine it here */
-#undef matchpathcon_filespec_add
 
 /* ABI backwards-compatible shim for non-LFS 32-bit systems */
-
 static_assert(sizeof(unsigned long) == sizeof(__ino_t), "inode size mismatch");
 static_assert(sizeof(unsigned long) == sizeof(uint32_t), "inode size mismatch");
 static_assert(sizeof(ino_t) == sizeof(ino64_t), "inode size mismatch");
 static_assert(sizeof(ino64_t) == sizeof(uint64_t), "inode size mismatch");
 
-extern int matchpathcon_filespec_add(unsigned long ino, int specind,
-                                     const char *file);
-
-int matchpathcon_filespec_add(unsigned long ino, int specind,
-                              const char *file)
-{
-	return matchpathcon_filespec_add64(ino, specind, file);
-}
 #elif (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || defined(__INO_T_MATCHES_INO64_T)
 
 static_assert(sizeof(uint64_t) == sizeof(ino_t), "inode size mismatch");


### PR DESCRIPTION
`matchpathcon_filespec_add` and `matchpathcon_filespec_add64` are exported in `libselinux.map`, so both need to be linker-visible symbols.

https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/libselinux.map#L85
https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/libselinux.map#L258

fix: #512