### PR TITLE
add test for fts_* availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ else
 		-fno-common
 endif
 
+# check for fts_* availability
+H := \#
+ifneq (yes,$(shell printf '${H}include <fts.h>\nint main(void){return fts_close(0);}' | $(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -Werror=implicit-function-declaration -x c -o /dev/null - >/dev/null 2>&1 && echo yes))
+export FTS_LDLIBS := -lfts
+endif
+
 ifneq ($(DESTDIR),)
 	LIBDIR ?= $(DESTDIR)$(PREFIX)/lib
 	LIBSEPOLA ?= $(LIBDIR)/libsepol.a

--- a/libselinux/src/Makefile
+++ b/libselinux/src/Makefile
@@ -99,9 +99,6 @@ override LDFLAGS += -L/opt/local/lib -undefined dynamic_lookup
 LD_SONAME_FLAGS=-install_name,$(LIBSO)
 endif
 
-# override with -lfts when building on Musl libc to use fts-standalone
-FTS_LDLIBS ?=
-
 override CFLAGS += -I../include -D_GNU_SOURCE $(DISABLE_FLAGS) $(PCRE_CFLAGS)
 
 # check for strlcpy(3) availability


### PR DESCRIPTION
check if fts libs are-builtin (glibc) or add `-flts` to use standalone fts (musl)

fix: #514