### PR TITLE
adjust audit2why map for python2 and 3

### DIFF
--- a/libselinux/src/audit2why-py2.map
+++ b/libselinux/src/audit2why-py2.map
@@ -1,0 +1,5 @@
+AUDIT2WHY_2.9 {
+  global:
+    initaudit2why;
+  local: *;
+};

--- a/libselinux/src/audit2why-py3.map
+++ b/libselinux/src/audit2why-py3.map
@@ -1,0 +1,5 @@
+AUDIT2WHY_2.9 {
+  global:
+    PyInit_audit2why;
+  local: *;
+};

--- a/libselinux/src/setup.py
+++ b/libselinux/src/setup.py
@@ -1,11 +1,21 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 
+import sys
 from setuptools import Extension, setup
+
+PY_MAJOR_VERSION = sys.version_info[0]
+
+if PY_MAJOR_VERSION >= 3:
+    audit2why_map = "audit2why-py3.map"
+    description = "SELinux python 3 bindings"
+else:
+    audit2why_map = "audit2why-py2.map"
+    description = "SELinux python 2 bindings"
 
 setup(
     name="selinux",
     version="3.10",
-    description="SELinux python 3 bindings",
+    description=description,
     author="SELinux Project",
     author_email="selinux@vger.kernel.org",
     ext_modules=[
@@ -19,6 +29,6 @@ setup(
                   include_dirs=['../include'],
                   library_dirs=['.'],
                   libraries=['selinux'],
-                  extra_link_args=['-l:libsepol.a', '-Wl,--version-script=audit2why.map'])
+                  extra_link_args=['-l:libsepol.a', "-Wl,--version-script={}".format(audit2why_map])
     ],
 )


### PR DESCRIPTION
align conditional python symbols creation and export.

Different symbols are defined for python2 and python3 in `audit2why.c`:
https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/audit2why.c#L456
https://github.com/SELinuxProject/selinux/blob/6be1ec3792c11040fd7a3ecb1135e54418eb0d57/libselinux/src/audit2why.c#L470-L475

Replicate this structure in `setup.py` and use individual maps for  python2 and python3.

fix: #461