### PR TITLE
checkpolicy: fix heap buffer overflow in define_fs_context()

### DIFF
--- a/checkpolicy/policy_define.c
+++ b/checkpolicy/policy_define.c
@@ -4856,13 +4856,15 @@ int define_fs_context(unsigned int major, unsigned int minor)
 		return -1;
 	}
 
-	newc->u.name = malloc(6);
+	/* "%02x:%02x" with two unsigned ints needs at most
+	 * "ffffffff:ffffffff" + NUL = 18 bytes. */
+	newc->u.name = malloc(18);
 	if (!newc->u.name) {
 		yyerror("out of memory");
 		free(newc);
 		return -1;
 	}
-	sprintf(newc->u.name, "%02x:%02x", major, minor);
+	snprintf(newc->u.name, 18, "%02x:%02x", major, minor);
 
 	if (parse_security_context(&newc->context[0])) {
 		free(newc->u.name);


### PR DESCRIPTION
## What

`define_fs_context()` in `checkpolicy/policy_define.c` allocates a fixed
6-byte buffer for the FSCON device-name key and then writes it with
`sprintf()`:

```c
newc->u.name = malloc(6);
...
sprintf(newc->u.name, "%02x:%02x", major, minor);
```

The `%02x` conversion only guarantees a *minimum* width of two; for
values above `0xff` each field expands up to eight hex digits, so the
worst case is `"ffffffff:ffffffff\0"` — 18 bytes — into a 6-byte heap
allocation.

`major` and `minor` are declared `unsigned int` and come straight from
the policy source through the `number` grammar rule
(`checkpolicy/policy_parse.y:712`), which is parsed by `strtoul()` and
capped only at `UINT_MAX`. Any `fscon` rule with a value `>= 0x100` in
either field already overflows the buffer.

## Reproducer

A standalone reproducer of the buggy pattern shows the heap write going
past the allocation:

```c
char *name = malloc(6);
sprintf(name, "%02x:%02x", 0x100u, 0u);
/* Output: "100:00\0" (7 bytes) -> 1-byte heap overflow */
```

```
typical: '01:02' (len=5)        // fits
major>0xff: '100:00' (len=6)    // off-by-one (NUL written OOB)
UINT_MAX: 'ffffffff:ffffffff' (len=17)  // 12-byte heap overflow
```

The equivalent in real checkpolicy input is:

```
fscon 256 0 system_u:object_r:fs_t:s0 system_u:object_r:fs_t:s0
```

## Fix

Enlarge the allocation to the worst-case size (`"ffffffff:ffffffff" +
NUL` = 18 bytes) and use `snprintf()` instead of `sprintf()` for
defense in depth.  Behaviour for in-range values is unchanged.

The change is confined to the callee (`define_fs_context()`); callers
and the `fscon` grammar rule are untouched.