### PR TITLE
checkpolicy: size fscon name buffer for full major:minor range

### DIFF
--- a/checkpolicy/policy_define.c
+++ b/checkpolicy/policy_define.c
@@ -4892,13 +4892,14 @@ int define_fs_context(unsigned int major, unsigned int minor)
 		return -1;
 	}
 
-	newc->u.name = malloc(6);
+	newc->u.name = malloc(sizeof("ffffffff:ffffffff"));
 	if (!newc->u.name) {
 		yyerror("out of memory");
 		free(newc);
 		return -1;
 	}
-	sprintf(newc->u.name, "%02x:%02x", major, minor);
+	snprintf(newc->u.name, sizeof("ffffffff:ffffffff"), "%02x:%02x", major,
+		 minor);
 
 	if (parse_security_context(&newc->context[0])) {
 		free(newc->u.name);


### PR DESCRIPTION
1. major and minor reach define_fs_context() through the `number` grammar rule, which runs strtoul and only rejects values above UINT_MAX, so fscon accepts numbers well beyond 0xff.
2. the ocontext name is allocated as malloc(6) and written with sprintf(name, "%02x:%02x", major, minor); six bytes only hold the result when both values are at most two hex digits. A policy line like `fscon 4294967295 4294967295 <ctx> <ctx>` formats to "ffffffff:ffffffff" (18 bytes including the terminator) and overflows the allocation by up to 12 bytes.
3. sized the buffer to the longest possible "%02x:%02x" output for two unsigned ints and switched to snprintf.

Checked the rest of the parser for the same pattern; this is the only fixed-size buffer fed by sprintf in policy_define.c.