### PR TITLE
libselinux: avoid out-of-bounds access on zero-length lines

### DIFF
--- a/libselinux/src/get_default_type.c
+++ b/libselinux/src/get_default_type.c
@@ -38,7 +38,7 @@ static int find_default_type(FILE *fp, const char *role, char **type)
 			errno = EINVAL;
 			return -1;
 		}
-		if (buf[strlen(buf) - 1])
+		if (buf[0] && buf[strlen(buf) - 1])
 			buf[strlen(buf) - 1] = 0;
 
 		ptr = buf;

--- a/libselinux/src/is_customizable_type.c
+++ b/libselinux/src/is_customizable_type.c
@@ -44,7 +44,8 @@ static void customizable_init(void)
 			i = 0;
 			while (fgets_unlocked(buf, selinux_page_size, fp) &&
 			       i < ctr) {
-				buf[strlen(buf) - 1] = 0;
+				if (buf[0])
+					buf[strlen(buf) - 1] = 0;
 				list[i] = strdup(buf);
 				if (!list[i]) {
 					unsigned int j;

--- a/libselinux/src/matchmediacon.c
+++ b/libselinux/src/matchmediacon.c
@@ -26,7 +26,7 @@ int matchmediacon(const char *media, char **con)
 			fclose(infile);
 			return -1;
 		}
-		if (current_line[strlen(current_line) - 1])
+		if (current_line[0] && current_line[strlen(current_line) - 1])
 			current_line[strlen(current_line) - 1] = 0;
 		/* Skip leading whitespace before the partial context. */
 		ptr = current_line;

--- a/libselinux/src/query_user_context.c
+++ b/libselinux/src/query_user_context.c
@@ -85,7 +85,7 @@ static void get_field(const char *fieldstr, char *newfield, int newfieldlen)
 		if (fgets(newfield, newfieldlen, stdin) == NULL)
 			continue;
 		fflush(stdin);
-		if (newfield[strlen(newfield) - 1] == '\n')
+		if (newfield[0] && newfield[strlen(newfield) - 1] == '\n')
 			newfield[strlen(newfield) - 1] = '\0';
 
 		if (strlen(newfield) == 0) {


### PR DESCRIPTION
1. find_default_type(), matchmediacon(), customizable_init(), and get_field() each read a line with fgets and then index buf[strlen(buf) - 1] to drop the trailing newline.
2. fgets stores a line that begins with a NUL byte, but strlen() then returns 0, so the index becomes buf[(size_t)-1], reading and (for the first three) writing one byte before the stack buffer.
3. Added a non-empty check before the index, the same guard already used in get_ordered_context_list() (get_context_list.c).

Confirmed under ASan with a default_type line beginning with a NUL byte: before, stack-buffer-underflow on the buf[strlen(buf) - 1] read; after, the line is skipped cleanly.