### PR TITLE
sestatus: null-terminate process and file check entries

### DIFF
--- a/policycoreutils/sestatus/sestatus.c
+++ b/policycoreutils/sestatus/sestatus.c
@@ -135,22 +135,24 @@ static void load_checks(char *pc[], int *npc, char *fc[], int *nfc)
 				case 0:
 					if (*npc >= MAX_CHECK)
 						break;
-					pc[*npc] = (char *)malloc((buf_len) *
+					pc[*npc] = (char *)malloc((buf_len + 1) *
 								  sizeof(char));
 					if (!pc[*npc])
 						break;
 					memcpy(pc[*npc], bufp, buf_len);
+					pc[*npc][buf_len] = '\0';
 					(*npc)++;
 					bufp = NULL;
 					break;
 				case 1:
 					if (*nfc >= MAX_CHECK)
 						break;
-					fc[*nfc] = (char *)malloc((buf_len) *
+					fc[*nfc] = (char *)malloc((buf_len + 1) *
 								  sizeof(char));
 					if (!fc[*nfc])
 						break;
 					memcpy(fc[*nfc], bufp, buf_len);
+					fc[*nfc][buf_len] = '\0';
 					(*nfc)++;
 					bufp = NULL;
 					break;


### PR DESCRIPTION
Repro: a `[process]` or `[files]` entry on the final line of /etc/sestatus.conf with no trailing newline.
Cause: load_checks() stores each entry with malloc(buf_len) then memcpy(dst, bufp, buf_len), so the buffer has no byte for a terminator and the copy is not null-terminated.
Fix: allocate buf_len + 1 and write the terminator at [buf_len] for both the process and file lists, since the entries are later read as C strings by pidof(), lgetfilecon(), lstat() and printf_tab().
