### PR TITLE
Ci refactor build

### DIFF
--- a/.github/actions/build-userspace/action.yml
+++ b/.github/actions/build-userspace/action.yml
@@ -33,6 +33,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        echo "::group::Install dependencies"
         sudo apt-get update -q
         sudo apt-get install -qy --no-install-recommends \
             bison \
@@ -51,15 +52,20 @@ runs:
             xmlto
 
         pip install flake8 setuptools build wheel
+        echo "::endgroup::"
 
     - name: Install Clang
       if: ${{ inputs.compiler == 'clang' }}
       shell: bash
-      run: sudo apt-get install -qqy clang
+      run: |
+        echo "::group::Install Clang"
+        sudo apt-get install -qqy clang
+        echo "::endgroup::"
 
     - name: Configure the environment
       shell: bash
       run: |
+        echo "::group::Configure the environment"
         DESTDIR=/tmp/destdir
         echo "PYTHON=python" >> $GITHUB_ENV
         echo "RUBY=ruby" >> $GITHUB_ENV
@@ -113,6 +119,7 @@ runs:
 
         # Display the final environment file, for debugging purpose
         cat $GITHUB_ENV
+        echo "::endgroup::"
 
     - name: Display versions
       shell: bash

--- a/.github/actions/build-userspace/action.yml
+++ b/.github/actions/build-userspace/action.yml
@@ -1,0 +1,139 @@
+name: Build SELinux userspace
+description: Set up Python, Ruby, install dependencies, and configure the build environment
+
+inputs:
+  python-version:
+    description: Python version to set up
+    required: true
+  ruby-version:
+    description: Ruby version to set up
+    required: true
+  compiler:
+    description: Compiler to use (gcc or clang)
+    required: true
+  other:
+    description: Additional build variant (test-flags-override, test-debug, linker-bfd, linker-gold, sanitizers)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Ruby ${{ inputs.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby-version }}
+        bundler-cache: true
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -q
+        sudo apt-get install -qy --no-install-recommends \
+            bison \
+            flex \
+            gawk \
+            gettext \
+            libaudit-dev \
+            libbz2-dev \
+            libcap-dev \
+            libcap-ng-dev \
+            libcunit1-dev \
+            libdbus-glib-1-dev \
+            libpcre2-dev \
+            ruby-dev \
+            swig \
+            xmlto
+
+        pip install flake8 setuptools build wheel
+
+    - name: Install Clang
+      if: ${{ inputs.compiler == 'clang' }}
+      run: sudo apt-get install -qqy clang
+
+    - name: Configure the environment
+      run: |
+        DESTDIR=/tmp/destdir
+        echo "PYTHON=python" >> $GITHUB_ENV
+        echo "RUBY=ruby" >> $GITHUB_ENV
+        echo "DESTDIR=$DESTDIR" >> $GITHUB_ENV
+
+        CC=${{ matrix.compiler }}
+        if [ "${{ matrix.python-ruby-version.other }}" = "linker-bfd" ] ; then
+            CC="$CC -fuse-ld=bfd"
+        elif [ "${{ matrix.python-ruby-version.other }}" = "linker-gold" ] ; then
+            CC="$CC -fuse-ld=gold"
+        fi
+        # https://bugs.ruby-lang.org/issues/18616
+        # https://github.com/llvm/llvm-project/issues/49958
+        if [ "${{ matrix.compiler }}" = "clang" ] && [[ "${{ matrix.python-ruby-version.ruby }}" = 3* ]] ; then
+            CC="$CC -fdeclspec"
+        fi
+        echo "CC=$CC" >> $GITHUB_ENV
+
+        EXPLICIT_MAKE_VARS=
+        if [ "${{ matrix.python-ruby-version.other }}" = "test-flags-override" ] ; then
+            # Test that overriding CFLAGS, LDFLAGS and other variables works fine
+            EXPLICIT_MAKE_VARS="CFLAGS=-I$DESTDIR/usr/include LDFLAGS=-L$DESTDIR/usr/lib LDLIBS= CPPFLAGS="
+        elif [ "${{ matrix.python-ruby-version.other }}" = "test-debug" ] ; then
+            # Test hat debug build works fine
+            EXPLICIT_MAKE_VARS="DEBUG=1"
+        elif [ "${{ matrix.python-ruby-version.other }}" = "sanitizers" ] ; then
+            sanitizers='-fsanitize=address,undefined'
+            EXPLICIT_MAKE_VARS="CFLAGS='-g -I$DESTDIR/usr/include $sanitizers' LDFLAGS='-L$DESTDIR/usr/lib $sanitizers' LDLIBS= CPPFLAGS= OPT_SUBDIRS="
+            echo "ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1" >> $GITHUB_ENV
+            echo "UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1" >> $GITHUB_ENV
+        else
+            EXPLICIT_MAKE_VARS=
+        fi
+        echo "EXPLICIT_MAKE_VARS=${EXPLICIT_MAKE_VARS}" >> $GITHUB_ENV
+
+        # Find files in order of pkgconf to be able to find Python.h
+        # For example with Python 3.5:
+        # * python is located at /opt/hostedtoolcache/Python/3.5.10/x64/bin/python
+        # * sys.prefix is /opt/hostedtoolcache/Python/3.5.10/x64
+        # * Python.h is located at /opt/hostedtoolcache/Python/3.5.10/x64/include/python3.5m/Python.h
+        # * python-3.5.pc is located at /opt/hostedtoolcache/Python/3.5.10/x64/lib/pkgconfig/python-3.5.pc
+        PYTHON_SYS_PREFIX="$(python -c 'import sys;print(sys.prefix)')"
+        echo "PKG_CONFIG_PATH=${PYTHON_SYS_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
+
+        if [[ "${{ matrix.python-ruby-version.python }}" == pypy* ]] ; then
+            # PyPy does not provide a config file for pkg-config
+            # libpypy-c.so is provided in bin/libpypy-c.so for PyPy and bin/libpypy3-c.so for PyPy3
+            echo "PYINC=-I${PYTHON_SYS_PREFIX}/include" >> $GITHUB_ENV
+            echo "PYLIBS=-L${PYTHON_SYS_PREFIX}/bin -lpypy3-c" >> $GITHUB_ENV
+        fi
+
+        # Display the final environment file, for debugging purpose
+        cat $GITHUB_ENV
+
+    - name: Display versions
+      run: |
+        echo "::group::Compiler ($CC):"
+        $CC --version
+        echo "::endgroup::"
+        echo "::group::Python ($(which "$PYTHON")):"
+        $PYTHON --version
+        echo "::endgroup::"
+        echo "::group::Ruby ($(which "$RUBY")):"
+        $RUBY --version
+        echo "::endgroup::"
+
+    - name: Build SELinux userspace
+      run: |
+        echo "::group::make install"
+        eval make -j$(nproc) install $EXPLICIT_MAKE_VARS -k
+        echo "::endgroup::"
+        echo "::group::make install"
+        eval make -j$(nproc) install $EXPLICIT_MAKE_VARS -k
+        echo "::endgroup::"
+        echo "::group::make install-pywrap"
+        eval make -j$(nproc) install-pywrap $EXPLICIT_MAKE_VARS -k
+        echo "::endgroup::"
+        echo "::group::make install-rubywrap"
+        eval make -j$(nproc) install-rubywrap $EXPLICIT_MAKE_VARS -k
+        echo "::endgroup::"

--- a/.github/actions/build-userspace/action.yml
+++ b/.github/actions/build-userspace/action.yml
@@ -31,6 +31,7 @@ runs:
         bundler-cache: true
 
     - name: Install dependencies
+      shell: bash
       run: |
         sudo apt-get update -q
         sudo apt-get install -qy --no-install-recommends \
@@ -53,9 +54,11 @@ runs:
 
     - name: Install Clang
       if: ${{ inputs.compiler == 'clang' }}
+      shell: bash
       run: sudo apt-get install -qqy clang
 
     - name: Configure the environment
+      shell: bash
       run: |
         DESTDIR=/tmp/destdir
         echo "PYTHON=python" >> $GITHUB_ENV
@@ -112,6 +115,7 @@ runs:
         cat $GITHUB_ENV
 
     - name: Display versions
+      shell: bash
       run: |
         echo "::group::Compiler ($CC):"
         $CC --version
@@ -124,6 +128,7 @@ runs:
         echo "::endgroup::"
 
     - name: Build SELinux userspace
+      shell: bash
       run: |
         echo "::group::make install"
         eval make -j$(nproc) install $EXPLICIT_MAKE_VARS -k

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,97 +41,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-ruby-version.python }}
-      uses: actions/setup-python@v5
+    - name: Build userspace
+      uses: ./.github/actions/build-userspace
       with:
         python-version: ${{ matrix.python-ruby-version.python }}
-
-    - name: Set up Ruby ${{ matrix.python-ruby-version.ruby }}
-      uses: ruby/setup-ruby@v1
-      with:
         ruby-version: ${{ matrix.python-ruby-version.ruby }}
-        bundler-cache: true
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update -q
-        sudo apt-get install -qy --no-install-recommends \
-            bison \
-            flex \
-            gawk \
-            gettext \
-            libaudit-dev \
-            libbz2-dev \
-            libcap-dev \
-            libcap-ng-dev \
-            libcunit1-dev \
-            libdbus-glib-1-dev \
-            libpcre2-dev \
-            ruby-dev \
-            swig \
-            xmlto
-
-        pip install flake8 setuptools build wheel
-
-    - name: Install Clang
-      if: ${{ matrix.compiler == 'clang' }}
-      run: sudo apt-get install -qqy clang
-
-    - name: Configure the environment
-      run: |
-        DESTDIR=/tmp/destdir
-        echo "PYTHON=python" >> $GITHUB_ENV
-        echo "RUBY=ruby" >> $GITHUB_ENV
-        echo "DESTDIR=$DESTDIR" >> $GITHUB_ENV
-
-        CC=${{ matrix.compiler }}
-        if [ "${{ matrix.python-ruby-version.other }}" = "linker-bfd" ] ; then
-            CC="$CC -fuse-ld=bfd"
-        elif [ "${{ matrix.python-ruby-version.other }}" = "linker-gold" ] ; then
-            CC="$CC -fuse-ld=gold"
-        fi
-        # https://bugs.ruby-lang.org/issues/18616
-        # https://github.com/llvm/llvm-project/issues/49958
-        if [ "${{ matrix.compiler }}" = "clang" ] && [[ "${{ matrix.python-ruby-version.ruby }}" = 3* ]] ; then
-            CC="$CC -fdeclspec"
-        fi
-        echo "CC=$CC" >> $GITHUB_ENV
-
-        EXPLICIT_MAKE_VARS=
-        if [ "${{ matrix.python-ruby-version.other }}" = "test-flags-override" ] ; then
-            # Test that overriding CFLAGS, LDFLAGS and other variables works fine
-            EXPLICIT_MAKE_VARS="CFLAGS=-I$DESTDIR/usr/include LDFLAGS=-L$DESTDIR/usr/lib LDLIBS= CPPFLAGS="
-        elif [ "${{ matrix.python-ruby-version.other }}" = "test-debug" ] ; then
-            # Test hat debug build works fine
-            EXPLICIT_MAKE_VARS="DEBUG=1"
-        elif [ "${{ matrix.python-ruby-version.other }}" = "sanitizers" ] ; then
-            sanitizers='-fsanitize=address,undefined'
-            EXPLICIT_MAKE_VARS="CFLAGS='-g -I$DESTDIR/usr/include $sanitizers' LDFLAGS='-L$DESTDIR/usr/lib $sanitizers' LDLIBS= CPPFLAGS= OPT_SUBDIRS="
-            echo "ASAN_OPTIONS=strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1" >> $GITHUB_ENV
-            echo "UBSAN_OPTIONS=print_stacktrace=1:print_summary=1:halt_on_error=1" >> $GITHUB_ENV
-        else
-            EXPLICIT_MAKE_VARS=
-        fi
-        echo "EXPLICIT_MAKE_VARS=${EXPLICIT_MAKE_VARS}" >> $GITHUB_ENV
-
-        # Find files in order of pkgconf to be able to find Python.h
-        # For example with Python 3.5:
-        # * python is located at /opt/hostedtoolcache/Python/3.5.10/x64/bin/python
-        # * sys.prefix is /opt/hostedtoolcache/Python/3.5.10/x64
-        # * Python.h is located at /opt/hostedtoolcache/Python/3.5.10/x64/include/python3.5m/Python.h
-        # * python-3.5.pc is located at /opt/hostedtoolcache/Python/3.5.10/x64/lib/pkgconfig/python-3.5.pc
-        PYTHON_SYS_PREFIX="$(python -c 'import sys;print(sys.prefix)')"
-        echo "PKG_CONFIG_PATH=${PYTHON_SYS_PREFIX}/lib/pkgconfig" >> $GITHUB_ENV
-
-        if [[ "${{ matrix.python-ruby-version.python }}" == pypy* ]] ; then
-            # PyPy does not provide a config file for pkg-config
-            # libpypy-c.so is provided in bin/libpypy-c.so for PyPy and bin/libpypy3-c.so for PyPy3
-            echo "PYINC=-I${PYTHON_SYS_PREFIX}/include" >> $GITHUB_ENV
-            echo "PYLIBS=-L${PYTHON_SYS_PREFIX}/bin -lpypy3-c" >> $GITHUB_ENV
-        fi
-
-        # Display the final environment file, for debugging purpose
-        cat $GITHUB_ENV
+        compiler: ${{ matrix.compiler }}
+        other: ${{ matrix.python-ruby-version.other }}
 
     - name: Download and install refpolicy headers for sepolgen tests
       run: |
@@ -145,30 +61,8 @@ jobs:
         sed -e "s,\"\(/usr/bin/[cs]\),\"$DESTDIR\1," -i python/sepolgen/src/sepolgen/module.py
         rm -r refpolicy refpolicy.tar.bz2
 
-    - name: Display versions
-      run: |
-        echo "::group::Compiler ($CC):"
-        $CC --version
-        echo "::endgroup::"
-        echo "::group::Python ($(which "$PYTHON")):"
-        $PYTHON --version
-        echo "::endgroup::"
-        echo "::group::Ruby ($(which "$RUBY")):"
-        $RUBY --version
-        echo "::endgroup::"
-
     - name: Run tests
       run: |
-        echo "::group::make install"
-        eval make -j$(nproc) install $EXPLICIT_MAKE_VARS -k
-        echo "::endgroup::"
-        echo "::group::make install-pywrap"
-        eval make -j$(nproc) install-pywrap $EXPLICIT_MAKE_VARS -k
-        echo "::endgroup::"
-        echo "::group::make install-rubywrap"
-        eval make -j$(nproc) install-rubywrap $EXPLICIT_MAKE_VARS -k
-        echo "::endgroup::"
-
         # Now that everything is installed, run "make all" to build everything which may have not been built
         echo "::group::make all"
         eval make -j$(nproc) all $EXPLICIT_MAKE_VARS -k


### PR DESCRIPTION
This patch set refactors the build step into a custom GH action.  This allows other projects (refpolicy, setools, etc.) to reuse these steps in their CI pipelines.

Example run with this set:
https://github.com/pebenito/selinux/actions/runs/27028226461


For an example use, I've made this change in the SETools CI pipeline. 
Then the SETools build that is part of the refpolicy CI simply calls 
SETools's build action:

https://github.com/SELinuxProject/refpolicy/blob/28ee79d5c811c75fb5ebef9d2c566f58a7c53cc2/.github/workflows/build-setools.yml#L56-L64

Mail list posting:
* https://lore.kernel.org/selinux/20260605171825.362853-1-chpebeni@linux.microsoft.com/T/#t