### PR TITLE
libsepol: cast to unsigned char in ctype calls

### DIFF
--- a/libsepol/cil/src/cil_build_ast.c
+++ b/libsepol/cil/src/cil_build_ast.c
@@ -4507,7 +4507,7 @@ int cil_gen_nodecon(struct cil_db *db, struct cil_tree_node *parse_current,
 	} else {
 		char *addr = parse_current->next->data;
 		if (strchr(addr, ':') ||
-		    (strchr(addr, '.') && isdigit(addr[0]))) {
+		    (strchr(addr, '.') && isdigit((unsigned char)addr[0]))) {
 			cil_ipaddr_init(&nodecon->addr);
 			rc = cil_fill_ipaddr(parse_current->next,
 					     nodecon->addr);
@@ -4529,7 +4529,7 @@ int cil_gen_nodecon(struct cil_db *db, struct cil_tree_node *parse_current,
 	} else {
 		char *mask = parse_current->next->next->data;
 		if (strchr(mask, ':') ||
-		    (strchr(mask, '.') && isdigit(mask[0]))) {
+		    (strchr(mask, '.') && isdigit((unsigned char)mask[0]))) {
 			cil_ipaddr_init(&nodecon->mask);
 			rc = cil_fill_ipaddr(parse_current->next->next,
 					     nodecon->mask);
@@ -5749,7 +5749,8 @@ int cil_fill_ipaddr(struct cil_tree_node *addr_node, struct cil_ipaddr *addr)
 	addr_str = addr_node->data;
 	if (strchr(addr_str, ':')) {
 		addr->family = AF_INET6;
-	} else if (strchr(addr_str, '.') && isdigit(addr_str[0])) {
+	} else if (strchr(addr_str, '.') &&
+		   isdigit((unsigned char)addr_str[0])) {
 		addr->family = AF_INET;
 	} else {
 		goto exit;

--- a/libsepol/cil/src/cil_verify.c
+++ b/libsepol/cil/src/cil_verify.c
@@ -115,7 +115,7 @@ int cil_verify_name(const struct cil_db *db, const char *name,
 		goto exit;
 	}
 
-	if (!isalpha(name[0])) {
+	if (!isalpha((unsigned char)name[0])) {
 		cil_log(CIL_ERR, "First character in %s is not a letter\n",
 			name);
 		goto exit;
@@ -123,8 +123,8 @@ int cil_verify_name(const struct cil_db *db, const char *name,
 
 	if (db->qualified_names == CIL_FALSE) {
 		for (i = 1; i < len; i++) {
-			if (!isalnum(name[i]) && name[i] != '_' &&
-			    name[i] != '-') {
+			if (!isalnum((unsigned char)name[i]) &&
+			    name[i] != '_' && name[i] != '-') {
 				cil_log(CIL_ERR,
 					"Invalid character \"%c\" in %s\n",
 					name[i], name);
@@ -133,8 +133,9 @@ int cil_verify_name(const struct cil_db *db, const char *name,
 		}
 	} else {
 		for (i = 1; i < len; i++) {
-			if (!isalnum(name[i]) && name[i] != '_' &&
-			    name[i] != '-' && name[i] != '.') {
+			if (!isalnum((unsigned char)name[i]) &&
+			    name[i] != '_' && name[i] != '-' &&
+			    name[i] != '.') {
 				cil_log(CIL_ERR,
 					"Invalid character \"%c\" in %s\n",
 					name[i], name);

--- a/libsepol/cil/src/cil_write_ast.c
+++ b/libsepol/cil/src/cil_write_ast.c
@@ -1708,7 +1708,7 @@ static int __write_parse_ast_node_helper(struct cil_tree_node *node,
 		size_t i;
 
 		for (i = 0; i < len; i++) {
-			if (isspace(str[i])) {
+			if (isspace((unsigned char)str[i])) {
 				fprintf(args->out, "\"%s\"\n", str);
 				return SEPOL_OK;
 			}

--- a/libsepol/src/module_to_cil.c
+++ b/libsepol/src/module_to_cil.c
@@ -118,7 +118,7 @@ static int get_line(char **start, char *end, char **line)
 
 	*line = NULL;
 
-	for (p = *start; p < end && isspace(*p); p++)
+	for (p = *start; p < end && isspace((unsigned char)*p); p++)
 		;
 
 	*start = p;
@@ -3534,7 +3534,7 @@ static int seusers_to_cil(struct sepol_module_package *mod_pkg)
 
 	while ((rc = get_line(&cur, end, &line)) > 0) {
 		tmp = line;
-		while (isspace(*tmp)) {
+		while (isspace((unsigned char)*tmp)) {
 			tmp++;
 		}
 
@@ -3627,7 +3627,7 @@ static int user_extra_to_cil(struct sepol_module_package *mod_pkg)
 
 	while ((rc = get_line(&cur, end, &line)) > 0) {
 		tmp = line;
-		while (isspace(*tmp)) {
+		while (isspace((unsigned char)*tmp)) {
 			tmp++;
 		}
 
@@ -3699,7 +3699,7 @@ static int file_contexts_to_cil(struct sepol_module_package *mod_pkg)
 
 	while ((rc = get_line(&cur, end, &line)) > 0) {
 		tmp = line;
-		while (isspace(*tmp)) {
+		while (isspace((unsigned char)*tmp)) {
 			tmp++;
 		}
 
@@ -4411,7 +4411,7 @@ static int fix_module_name(struct policydb *pdb)
 	// CIL is more restrictive in module names than checkmodule. Convert bad
 	// characters to underscores
 	for (letter = pdb->name; *letter != '\0'; letter++) {
-		if (isalnum(*letter)) {
+		if (isalnum((unsigned char)*letter)) {
 			continue;
 		}
 

--- a/libsepol/src/util.c
+++ b/libsepol/src/util.c
@@ -248,10 +248,11 @@ static inline int tokenize_str(char delim, char **str, const char **ptr,
 	*str = NULL;
 
 	while (**ptr != '\0') {
-		if (isspace(delim) && isspace(**ptr)) {
+		if (isspace((unsigned char)delim) &&
+		    isspace((unsigned char)**ptr)) {
 			(*ptr)++;
 			break;
-		} else if (!isspace(delim) && **ptr == delim) {
+		} else if (!isspace((unsigned char)delim) && **ptr == delim) {
 			(*ptr)++;
 			break;
 		}
@@ -273,7 +274,8 @@ static inline int tokenize_str(char delim, char **str, const char **ptr,
 	}
 
 	/* Squash spaces if the delimiter is a whitespace character */
-	while (**ptr != '\0' && isspace(delim) && isspace(**ptr)) {
+	while (**ptr != '\0' && isspace((unsigned char)delim) &&
+	       isspace((unsigned char)**ptr)) {
 		(*ptr)++;
 	}
 


### PR DESCRIPTION
Repro: feed a binary policy module or CIL source whose module name, seusers/file_contexts line, identifier, or IP token holds a byte >= 0x80 to the module-to-CIL or CIL parsing paths, built where char is signed (the x86/ARM default).
Cause: tokenize_str(), get_line(), the *_to_cil()/fix_module_name() helpers, cil_gen_nodecon(), cil_fill_ipaddr(), the AST writer, and cil_verify_name() pass a plain char to isspace/isalnum/isalpha/isdigit, so a high-bit byte sign-extends to a negative int, outside the unsigned char or EOF domain those functions accept (C11 7.4p1).
Fix: cast each argument to unsigned char at the call sites in util.c, module_to_cil.c, cil_build_ast.c, cil_write_ast.c and cil_verify.c, matching the cast already used across libselinux.
