### PR TITLE
libsepol: fix out-of-bounds typealias_lists access in module_to_cil

### DIFF
--- a/libsepol/src/module_to_cil.c
+++ b/libsepol/src/module_to_cil.c
@@ -377,9 +377,11 @@ static int typealias_list_create(struct policydb *pdb)
 	uint32_t rc = -1;
 
 	for (block = pdb->global; block != NULL; block = block->next) {
-		decl = block->branch_list;
-		if (decl != NULL && decl->decl_id > max_decl_id) {
-			max_decl_id = decl->decl_id;
+		for (decl = block->branch_list; decl != NULL;
+		     decl = decl->next) {
+			if (decl->decl_id > max_decl_id) {
+				max_decl_id = decl->decl_id;
+			}
 		}
 	}
 


### PR DESCRIPTION
1. typealias_list_create() sizes typealias_lists from max_decl_id, but the loop only looks at block->branch_list (the first decl of each block), so the decl ids of else branches in optional blocks are never counted.
2. typealiases_gather_map() then indexes typealias_lists with scope->decl_ids[len - 1]; for a type alias declared inside an optional's else branch that id is one of the uncounted ones, so both the read at typealias_lists[scope_id] and the list_init write run past the end of the array.

Walking the full branch_list when computing max_decl_id sizes the array for every declaration id.

Reproduced by converting a base module that declares a typealias in an optional else branch through sepol_module_package_to_cil(); placing the array end on a guard page makes the access fault, and the fault is gone after the change.