### PR TITLE
libsepol: null-terminate temporary buffer in mls_to_string

### DIFF
--- a/libsepol/src/mls.c
+++ b/libsepol/src/mls.c
@@ -50,6 +50,7 @@ int mls_to_string(sepol_handle_t *handle, const policydb_t *policydb,
 	ptr = (char *)malloc(len);
 	if (ptr == NULL)
 		goto omem;
+	ptr[len - 1] = '\0';
 
 	/* Final string w/ ':' cut off */
 	ptr2 = (char *)malloc(len - 1);


### PR DESCRIPTION
mls_to_string allocates a temporary buffer of mls_compute_context_len() + 1 bytes and fills it with mls_sid_to_context(), which writes exactly that many bytes without a NUL terminator. The following strcpy() then reads past the written data (an uninitialized byte and then out of bounds) and can write past the end of the destination, hit whenever an MLS context or user range is converted to a string (context_to_record and the user enumeration paths). Terminating the buffer before the copy, as context_to_string() already does, fixes it.