### PR TITLE
libsepol: bound category values in mls_semantic_level_expand

### DIFF
--- a/libsepol/src/expand.c
+++ b/libsepol/src/expand.c
@@ -1128,11 +1128,13 @@ int mls_semantic_level_expand(mls_semantic_level_t *sl, mls_level_t *l,
 		return -1;
 	}
 	for (cat = sl->cat; cat; cat = cat->next) {
-		if (!cat->low || cat->low > cat->high) {
+		if (!cat->low || cat->low > cat->high ||
+		    cat->high > p->p_cats.nprim) {
 			ERR(h, "Category range is not valid %s.%s",
-			    cat->low > 0 ? p->p_cat_val_to_name[cat->low - 1] :
-					   "Invalid",
-			    cat->high > 0 ?
+			    (cat->low && cat->low <= p->p_cats.nprim) ?
+				    p->p_cat_val_to_name[cat->low - 1] :
+				    "Invalid",
+			    (cat->high && cat->high <= p->p_cats.nprim) ?
 				    p->p_cat_val_to_name[cat->high - 1] :
 				    "Invalid");
 			return -1;


### PR DESCRIPTION
1. mls_semantic_level_expand() checks the sensitivity against p_levels.nprim but never bounds the per-category low/high values against p_cats.nprim.
2. For a base module the user MLS range and default level are read in semantic form with no bounds check, and policydb_read() expands them through policydb_index_others() -> policydb_user_cache() before policydb_validate() runs, so a crafted base policy with a category value past the declared count reads p_cat_val_to_name[] out of bounds, both in the "Category range is not valid" message and in the p_cat_val_to_name[i] reference inside the loop.
3. Reject cat->high > p_cats.nprim and guard the error-message indices with the same upper bound, matching the existing sensitivity check just above.

Confirmed under ASAN: a semantic level with a category low/high beyond the declared category count reports a heap-buffer-overflow read in mls_semantic_level_expand before the patch, and is rejected cleanly with an error after it.