### PR TITLE
libsemanage: guard end of path in semanage_fc_find_meta

### DIFF
--- a/libsemanage/src/semanage_store.c
+++ b/libsemanage/src/semanage_store.c
@@ -2530,6 +2530,8 @@ static void semanage_fc_find_meta(semanage_file_context_node_t *fc_node)
 			/* If an escape character is found,
 			 *  skip the next character. */
 			c++;
+			if (fc_node->path[c] == '\0')
+				return;
 			escape_chars++;
 			break;
 		}


### PR DESCRIPTION
1. semanage_fc_find_meta() skips the byte after a backslash with c++ but never checks whether that skip reached the terminating NUL.
2. a file_contexts regex token ending in a single backslash advances c onto the NUL, then the loop-tail c++ moves one further, so the while condition reads one byte past the strndup buffer (heap-buffer-overflow read, confirmed under ASan).
3. semanage_fc_sort() builds that token from file_contexts content, so the byte enters from a policy module the parser is meant to handle.

Returned when the skip lands on the NUL, matching the guard already used by the same metachar scan in cil_post.c.