### PR TITLE
mcstrans: fix out-of-bounds read in parse_raw sensitivity parsing

### DIFF
--- a/mcstrans/src/mcstrans.c
+++ b/mcstrans/src/mcstrans.c
@@ -173,41 +173,35 @@ err:
 	return -1;
 }
 
-static int numdigits(unsigned int n)
-{
-	int count = 1;
-	while ((n = n / 10))
-		count++;
-	return count;
-}
-
 static int parse_category(ebitmap_t *e, const char *raw, bool allowinverse,
 			  bool fromconfig)
 {
 	int inverse = 0;
 	unsigned int low, high;
 	while (*raw) {
+		int n = 0;
 		if (allowinverse && *raw == '~') {
 			inverse = !inverse;
 			raw++;
 			continue;
 		}
-		if (sscanf(raw, "c%u", &low) != 1)
+		if (sscanf(raw, "c%u%n", &low, &n) != 1)
 			return -1;
 		if (low >= MAX_CATS)
 			return -1;
 		if (!fromconfig && low >= maxbit)
 			return -1;
-		raw += numdigits(low) + 1;
+		raw += n;
 		if (*raw == '.') {
 			raw++;
-			if (sscanf(raw, "c%u", &high) != 1)
+			n = 0;
+			if (sscanf(raw, "c%u%n", &high, &n) != 1)
 				return -1;
 			if (high >= MAX_CATS)
 				return -1;
 			if (!fromconfig && high >= maxbit)
 				return -1;
-			raw += numdigits(high) + 1;
+			raw += n;
 		} else {
 			high = low;
 		}
@@ -242,11 +236,12 @@ static int parse_ebitmap(ebitmap_t *e, ebitmap_t *def, const char *raw)
 static mls_level_t *parse_raw(const char *raw, bool fromconfig)
 {
 	mls_level_t *mls = calloc(1, sizeof(mls_level_t));
+	int n = 0;
 	if (!mls)
 		return NULL;
-	if (sscanf(raw, "s%u", &mls->sens) != 1)
+	if (sscanf(raw, "s%u%n", &mls->sens, &n) != 1)
 		goto err;
-	raw += numdigits(mls->sens) + 1;
+	raw += n;
 	if (*raw == ':') {
 		raw++;
 		if (parse_category(&mls->cat, raw, false, fromconfig) < 0)


### PR DESCRIPTION
Repro: send mcstransd a context whose range high level is "s-1" (e.g. the range "s0-s-1"); trans_context() splits the range on its first dash and calls parse_raw("s-1").

Cause: parse_raw() advances the cursor with raw += numdigits(sens) + 1 after sscanf(raw, "s%u", &sens). sscanf %u accepts a leading minus, so "s-1" stores UINT_MAX into sens and numdigits() returns 10 while only two characters were consumed. raw moves 11 bytes past the 4-byte allocation and the next *raw == : test reads out of bounds. The string is attacker-controlled: it is the MLS range of any context handed to the mcstransd socket via trans_context()/untrans_context() -> extract_range() -> compute_trans_from_raw(). parse_category() advances with the same numdigits construct at two sites; those are currently shielded only by the >= MAX_CATS checks.

Fix: advance by the number of characters sscanf actually consumed via %n at all three sites and drop numdigits(). Validated with an ASAN build of the parse_raw sensitivity logic: input "s-1" reports a heap-buffer-overflow read 7 bytes past the 4-byte buffer before the change, and runs clean after; "s5", "s5:c1.c3" and "s0" parse unchanged.