### PR TITLE
libsepol/cil: fix double free of borrowed type datum on error path

### DIFF
--- a/libsepol/cil/src/cil_binary.c
+++ b/libsepol/cil/src/cil_binary.c
@@ -611,18 +611,13 @@ int cil_typepermissive_to_policydb(policydb_t *pdb,
 	rc = __cil_get_sepol_type_datum(pdb, DATUM(cil_typeperm->type),
 					&sepol_type);
 	if (rc != SEPOL_OK)
-		goto exit;
+		return rc;
 
 	if (ebitmap_set_bit(&pdb->permissive_map, sepol_type->s.value, 1)) {
-		goto exit;
+		return rc;
 	}
 
 	return SEPOL_OK;
-
-exit:
-	type_datum_destroy(sepol_type);
-	free(sepol_type);
-	return rc;
 }
 
 int cil_typeneveraudit_to_policydb(policydb_t *pdb,
@@ -634,18 +629,13 @@ int cil_typeneveraudit_to_policydb(policydb_t *pdb,
 	rc = __cil_get_sepol_type_datum(pdb, DATUM(cil_typeperm->type),
 					&sepol_type);
 	if (rc != SEPOL_OK)
-		goto exit;
+		return rc;
 
 	if (ebitmap_set_bit(&pdb->neveraudit_map, sepol_type->s.value, 1)) {
-		goto exit;
+		return rc;
 	}
 
 	return SEPOL_OK;
-
-exit:
-	type_datum_destroy(sepol_type);
-	free(sepol_type);
-	return rc;
 }
 
 int cil_typeattribute_to_policydb(policydb_t *pdb,


### PR DESCRIPTION
1. cil_typepermissive_to_policydb() and cil_typeneveraudit_to_policydb() set sepol_type from __cil_get_sepol_type_datum(), which is a hashtab_search() into pdb->p_types, so the datum is owned by the policydb.
2. their error path (taken when ebitmap_set_bit on permissive_map/neveraudit_map fails) calls type_datum_destroy(sepol_type) and free(sepol_type), and the same type is then freed again by type_destroy() during policydb_destroy(), a double free.
Removed the destroy and free of the borrowed datum from both error paths. The sibling alias converters (cil_typealias/cil_catalias/cil_sensalias_to_policydb) already follow this rule, freeing only their own allocation and leaving the lookup result alone.